### PR TITLE
Updated AMI of redhat image (using 9 not 8 now) added new var for AWS profiles

### DIFF
--- a/driver-gateway/README.md
+++ b/driver-gateway/README.md
@@ -16,6 +16,7 @@ Pre-requisites:
 5. Create the infrastructure with `terraform apply`
    1. You can change the value of num_instances using -var='num_instances={"client"=5, "gateway"=4, "kafka"=2}'
    2. You might also need to change the AWS profile with -var='aws_profile=your_profile'
+   3. With SSO the session does expire so you might need to run `aws sso login --profile your_profile` before running terraform
 6. Export your harbor creds https://harbor.cdkt.dev/
    1. Click your name in the top right corner and select User Profile then take your username and CLI secret
    2. export REGISTRY_USERNAME=Ben_Starmer-Smith

--- a/driver-gateway/README.md
+++ b/driver-gateway/README.md
@@ -14,9 +14,15 @@ Pre-requisites:
 3. Go to the `driver-gateway/deploy/ssd-deployment` module
 4. Initialize terraform with `terraform init`
 5. Create the infrastructure with `terraform apply`
-6. Setup nodes with `ansible-playbook --user ec2-user --inventory-file inventory.ini deploy.yaml`
-7. Connect to one benchmark worker node with `ssh -i ~/.ssh/kafka_aws ec2-user@$(terraform output client_ssh_host | tr -d '"')`
-8. Go to benchmark directory with `cd /opt/benchmark`
-9. Run the benchmark with `sudo bin/benchmark --drivers driver-gateway/gateway-latency.yaml workloads/100-topic-4-partitions-1kb-4p-4c-500k.yaml;`
-10. Download reports from nodes with `scp -i ~/.ssh/kafka_aws ec2-user@$(terraform output client_ssh_host | tr -d '"'):/opt/benchmark/*.json ./reports`
+   1. You can change the value of num_instances using -var='num_instances={"client"=5, "gateway"=4, "kafka"=2}'
+   2. You might also need to change the AWS profile with -var='aws_profile=your_profile'
+6. Export your harbor creds https://harbor.cdkt.dev/
+   1. Click your name in the top right corner and select User Profile then take your username and CLI secret
+   2. export REGISTRY_USERNAME=Ben_Starmer-Smith
+   3. export REGISTRY_PASSWORD=<CLI Secret>
+7. Setup nodes with `ansible-playbook --user ec2-user --inventory-file inventory.ini deploy.yaml`
+8. Connect to one benchmark worker node with `ssh -i ~/.ssh/kafka_aws ec2-user@$(terraform output client_ssh_host | tr -d '"')`
+9.  Go to benchmark directory with `cd /opt/benchmark`
+10. Run the benchmark with `sudo bin/benchmark --drivers driver-gateway/gateway-latency.yaml workloads/100-topic-4-partitions-1kb-4p-4c-500k.yaml;`
+11. Download reports from nodes with `scp -i ~/.ssh/kafka_aws ec2-user@$(terraform output client_ssh_host | tr -d '"'):/opt/benchmark/*.json ./reports`
 

--- a/driver-gateway/README.md
+++ b/driver-gateway/README.md
@@ -19,8 +19,8 @@ Pre-requisites:
    3. With SSO the session does expire so you might need to run `aws sso login --profile your_profile` before running terraform
 6. Export your harbor creds https://harbor.cdkt.dev/
    1. Click your name in the top right corner and select User Profile then take your username and CLI secret
-   2. export REGISTRY_USERNAME=Ben_Starmer-Smith
-   3. export REGISTRY_PASSWORD=<CLI Secret>
+   2. export REGISTRY_USERNAME=<registry login>
+   3. export REGISTRY_PASSWORD=<registry api token>
 7. Setup nodes with `ansible-playbook --user ec2-user --inventory-file inventory.ini deploy.yaml`
 8. Connect to one benchmark worker node with `ssh -i ~/.ssh/kafka_aws ec2-user@$(terraform output client_ssh_host | tr -d '"')`
 9.  Go to benchmark directory with `cd /opt/benchmark`

--- a/driver-gateway/deploy/ssd-deployment/ansible.cfg
+++ b/driver-gateway/deploy/ssd-deployment/ansible.cfg
@@ -1,4 +1,5 @@
 [defaults]
+interpreter_python = /usr/bin/python3
 private_key_file=~/.ssh/kafka_aws
 remote_user=ec2-user
 # ansible optimization https://www.redhat.com/sysadmin/faster-ansible-playbook-execution

--- a/driver-gateway/deploy/ssd-deployment/provision-kafka-aws.tf
+++ b/driver-gateway/deploy/ssd-deployment/provision-kafka-aws.tf
@@ -13,6 +13,7 @@ terraform {
 }
 provider "aws" {
   region  = "${var.region}"
+  profile = "${var.profile}"
 }
 
 provider "random" {
@@ -40,6 +41,8 @@ variable "key_name" {
 }
 
 variable "region" {}
+
+variable "profile" {}
 
 variable "ami" {}
 

--- a/driver-gateway/deploy/ssd-deployment/terraform.tfvars
+++ b/driver-gateway/deploy/ssd-deployment/terraform.tfvars
@@ -1,7 +1,9 @@
 public_key_path = "~/.ssh/kafka_aws.pub"
 region          = "us-west-2"
 az              = "us-west-2a"
-ami             = "ami-08970fb2e5767e3b8" // RHEL-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2
+profile         = "cdk-dev"
+ami             = "ami-04a616933df665b44" // RHEL-9.0.0_HVM-20220513-x86_64-0-Hourly2-GP2	
+#ami             = "ami-08970fb2e5767e3b8" // RHEL-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2
 #ami             = "ami-0b0b4a49742d64899" // RHEL-8.6.0_HVM-20240521-x86_64-58-Hourly2-GP3
 
 instance_types = {


### PR DESCRIPTION
Added some new variables for AWS profiles. Updated the readme to include harbor steps and some overriding vars. defined where to expect python interpreter in the image.

Why:
When running the ansible stage of setting up the enviorment, we we're having issues with running python at first its because it was using the wrong python path so we defined that in the `ansible.cfg`. However, this led to another issue, this was resolved by using a newer redhat 9 image that had a later python version. Also added profile support as its easier to setup a profile once and re-use it rather then session tokens that expire and need to be reset each time.