### PR TITLE
Fix AWS profile causing GH Action to break.

### DIFF
--- a/driver-gateway/deploy/ssd-deployment/provision-kafka-aws.tf
+++ b/driver-gateway/deploy/ssd-deployment/provision-kafka-aws.tf
@@ -13,7 +13,7 @@ terraform {
 }
 provider "aws" {
   region  = "${var.region}"
-  profile = "${var.profile}"
+  profile = var.profile != "" ? var.profile : null
 }
 
 provider "random" {

--- a/driver-gateway/deploy/ssd-deployment/terraform.tfvars
+++ b/driver-gateway/deploy/ssd-deployment/terraform.tfvars
@@ -1,7 +1,7 @@
 public_key_path = "~/.ssh/kafka_aws.pub"
 region          = "us-west-2"
 az              = "us-west-2a"
-profile         = "cdk-dev"
+profile         = ""
 ami             = "ami-04a616933df665b44" // RHEL-9.0.0_HVM-20220513-x86_64-0-Hourly2-GP2	
 #ami             = "ami-08970fb2e5767e3b8" // RHEL-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2
 #ami             = "ami-0b0b4a49742d64899" // RHEL-8.6.0_HVM-20240521-x86_64-58-Hourly2-GP3


### PR DESCRIPTION
Why:
When running the GitHub action to run the benchmark we were getting the error:
```
│ Error: failed to get shared config profile, cdk-dev
│ 
│   with provider["registry.terraform.io/hashicorp/aws"],
│   on provision-kafka-aws.tf line 14, in provider "aws":
│   14: provider "aws" {
│ 
╵
```
This is because the action uses ENV vars to setup the AWS workspace, I added the profile for local testing.
Fix:
Changed default profile to empty string. If this string is empty when running terraform it will not use a profile and instead use env vars.