### PR TITLE
BugFix - Add missing package pygl

### DIFF
--- a/driver-gateway/deploy/ssd-deployment/deploy.yaml
+++ b/driver-gateway/deploy/ssd-deployment/deploy.yaml
@@ -307,6 +307,10 @@
   connection: ssh
   become: true
   tasks:
+    - name: Install pygal
+      pip:
+        name: pygal
+        state: present
     - file: path=/opt/benchmark state=absent
       tags: [client-code]
     - name: Copy benchmark code


### PR DESCRIPTION
When setting up the environments using Ansible we now install pygal as we are setting up the client. Which is used to generate the end report.