### PR TITLE
Add pip install to ansible setup

### DIFF
--- a/driver-gateway/deploy/ssd-deployment/deploy.yaml
+++ b/driver-gateway/deploy/ssd-deployment/deploy.yaml
@@ -104,6 +104,7 @@
       yum: pkg={{ item }} state=installed
       with_items:
         - python3
+        - python3-pip
         - wget
         - java-17-openjdk
         - sysstat


### PR DESCRIPTION
Add pip install to ansible setup. As it was giving the error:
```
fatal: [54.212.14.189]: FAILED! => {"changed": false, "msg": "Unable to find any of pip3 to use.  pip needs to be installed."}
```