### PR TITLE
Bumped all download/upload-artifact actions to be > v3.

### DIFF
--- a/.github/workflows/pr-build-and-test.yml
+++ b/.github/workflows/pr-build-and-test.yml
@@ -37,7 +37,7 @@ jobs:
           mkdir test-results
           find . -type d -name "*surefire*" -exec cp --parents -R {} test-results/ \;
           zip -r test-results.zip test-results
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         name: upload test-results
         if: failure()
         with:


### PR DESCRIPTION
Why:
Artifact actions v3 will be deprecated by December 5, 2024.

Impact:
There is a small impact see [here](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes). However, the breaking changes do not affect us.