### PR TITLE
Switched the GW logging to INFO from DEBUG

### DIFF
--- a/driver-gateway/deploy/ssd-deployment/deploy.yaml
+++ b/driver-gateway/deploy/ssd-deployment/deploy.yaml
@@ -256,8 +256,8 @@
         volumes:
           - "/opt/gateway-interceptors.json:/opt/interceptors.json"
         env:
-          LOG4J2_IO_CONDUKTOR_PROXY_SERVICE_LEVEL: "DEBUG"
-          LOG4J2_IO_CONDUKTOR_PROXY_NETWORK_LEVEL: "DEBUG"
+          LOG4J2_IO_CONDUKTOR_PROXY_SERVICE_LEVEL: "INFO"
+          LOG4J2_IO_CONDUKTOR_PROXY_NETWORK_LEVEL: "INFO"
           LOG4J2_IO_NETTY_LEVEL: "INFO"
           KAFKA_BOOTSTRAP_SERVERS: "{{ bootstrapServers }}"
           GATEWAY_ADVERTISED_HOST: "{{ privateIp }}"


### PR DESCRIPTION
Switched the GW logging to INFO from DEBUG to help with GW benchmark performance and quiten the log noise.