### PR TITLE
Increased tagging across TF resources

### DIFF
--- a/driver-gateway/deploy/ssd-deployment/provision-kafka-aws.tf
+++ b/driver-gateway/deploy/ssd-deployment/provision-kafka-aws.tf
@@ -107,7 +107,7 @@ resource "aws_kms_key_policy" "benchmark_key" {
 # Create an internet gateway to give our subnet access to the outside world
 resource "aws_internet_gateway" "kafka" {
   vpc_id = "${aws_vpc.benchmark_vpc.id}"
-  tags = aws_instance.client
+  tags = var.common_tags
 }
 
 # Grant the VPC internet access on its main route table

--- a/driver-gateway/deploy/ssd-deployment/terraform.tfvars
+++ b/driver-gateway/deploy/ssd-deployment/terraform.tfvars
@@ -19,3 +19,10 @@ num_instances = {
   "kafka"     = 3
   "zookeeper" = 3
 }
+
+common_tags = {
+  CostCenter  = "Benchmarking"
+  Benchmark   = "Gateway"
+  Project     = "GatewayBenchmark"
+  CreatedBy   = "Terraform"
+}


### PR DESCRIPTION
Added a bunch of default tags to ensure all resources provisioned by the benchmark are tagged (if possible) and allocated to a costcenter for future analysis on spending.