### PR TITLE
3.10.0 acl disabled override

### DIFF
--- a/driver-gateway/deploy/ssd-deployment/deploy.yaml
+++ b/driver-gateway/deploy/ssd-deployment/deploy.yaml
@@ -268,6 +268,7 @@
           ENCRYPT_SECRET_KEY: "{{ lookup('ansible.builtin.env', 'ENCRYPT_SECRET_KEY') }}"
           GATEWAY_INTERCEPTOR_CONFIG_LOCATION: "/opt/interceptors.json"
           GATEWAY_ADMIN_API_USERS: "[{username: admin, password: conduktor, admin: true}]"
+          GATEWAY_ACL_ENABLED: "false"
         published_ports:
           - "8888:8888"
           - "6969:6969"


### PR DESCRIPTION
Due to changes in acl enabled default behaviour (see [docs](https://docs.conduktor.io/gateway/how-to/migration-guide-to-security-mode/)), to maintain consistent test suite we must manually override GATEWAY_ACL_ENABLED