### PR TITLE
Add opt-in CHOP ramp-discovery algorithm for max-sustainable-rate probing

### DIFF
--- a/benchmark-framework/RATE_FINDING.md
+++ b/benchmark-framework/RATE_FINDING.md
@@ -107,27 +107,31 @@ Unlike AIMD, CHOP runs to completion **before** warmup starts (`runChopDiscovery
 
 ### Configuration (workload YAML fields, all optional, only apply when `producerRate: 0`)
 
-|           Field            |                Default                 |                                                                                                                                               Applies to                                                                                                                                               |
-|----------------------------|----------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `rampAlgorithm`            | `AIMD`                                 | Selects the algorithm                                                                                                                                                                                                                                                                                  |
-| `rampStartRate`            | 10000                                  | Both                                                                                                                                                                                                                                                                                                   |
-| `rampPublishBacklogLimit`  | env `PUBLISH_BACKLOG_LIMIT`, else 1000 | Both                                                                                                                                                                                                                                                                                                   |
-| `rampReceiveBacklogLimit`  | env `RECEIVE_BACKLOG_LIMIT`, else 1000 | Both                                                                                                                                                                                                                                                                                                   |
-| `rampMaxBacklogSeconds`    | unset                                  | CHOP only — when set, replaces the two fields above with a limit that scales with the candidate rate (`limit = currentRate * rampMaxBacklogSeconds`), so the check is equally strict at every rate tried during bracket's exponential range instead of being loose at high rates and tight at low ones |
-| `rampBracketPeriodSeconds` | 3                                      | CHOP only — poll cadence, not a hold duration                                                                                                                                                                                                                                                          |
-| `rampSettleSeconds`        | 30                                     | CHOP only — grace period at start before backlog counts at all                                                                                                                                                                                                                                         |
-| `rampBracketHoldSeconds`   | resolved `rampHoldSeconds`             | CHOP only — how long a bracket candidate must hold clean; shorten independently once you trust bracket's coarser candidates need less scrutiny                                                                                                                                                         |
-| `rampHoldSeconds`          | 30                                     | CHOP only — how long a chop candidate must hold clean                                                                                                                                                                                                                                                  |
-| `rampConfirmationHolds`    | 1                                      | CHOP only                                                                                                                                                                                                                                                                                              |
-| `rampConvergenceTolerance` | 0.05                                   | CHOP only                                                                                                                                                                                                                                                                                              |
-| `rampMaxDiscoveryMinutes`  | 10                                     | CHOP only                                                                                                                                                                                                                                                                                              |
+|           Field            |                Default                 |                                                                                                                                                             Applies to                                                                                                                                                             |
+|----------------------------|----------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `rampAlgorithm`            | `AIMD`                                 | Selects the algorithm                                                                                                                                                                                                                                                                                                              |
+| `rampStartRate`            | 10000                                  | Both                                                                                                                                                                                                                                                                                                                               |
+| `rampPublishBacklogLimit`  | env `PUBLISH_BACKLOG_LIMIT`, else 1000 | Both                                                                                                                                                                                                                                                                                                                               |
+| `rampReceiveBacklogLimit`  | env `RECEIVE_BACKLOG_LIMIT`, else 1000 | Both                                                                                                                                                                                                                                                                                                                               |
+| `rampMaxBacklogSeconds`    | unset                                  | CHOP only — when set, replaces the two fields above with a limit that scales with the candidate rate (`limit = min(currentRate * rampMaxBacklogSeconds, rampMaxBacklogCeiling)`), so the check is equally strict at every rate tried during bracket's exponential range instead of being loose at high rates and tight at low ones |
+| `rampMaxBacklogCeiling`    | 100000                                 | CHOP only — hard cap (messages) on the limit `rampMaxBacklogSeconds` computes; only meaningful when `rampMaxBacklogSeconds` is set (see "Trial finding" below for why this exists)                                                                                                                                                 |
+| `rampBracketPeriodSeconds` | 3                                      | CHOP only — poll cadence, not a hold duration                                                                                                                                                                                                                                                                                      |
+| `rampSettleSeconds`        | 30                                     | CHOP only — grace period at start before backlog counts at all                                                                                                                                                                                                                                                                     |
+| `rampBracketHoldSeconds`   | resolved `rampHoldSeconds`             | CHOP only — how long a bracket candidate must hold clean; shorten independently once you trust bracket's coarser candidates need less scrutiny                                                                                                                                                                                     |
+| `rampHoldSeconds`          | 30                                     | CHOP only — how long a chop candidate must hold clean                                                                                                                                                                                                                                                                              |
+| `rampConfirmationHolds`    | 1                                      | CHOP only                                                                                                                                                                                                                                                                                                                          |
+| `rampConvergenceTolerance` | 0.05                                   | CHOP only                                                                                                                                                                                                                                                                                                                          |
+| `rampMaxDiscoveryMinutes`  | 10                                     | CHOP only                                                                                                                                                                                                                                                                                                                          |
 
 See `workloads/max-rate-chop-1-topic-100-partitions-100b.yaml` for a runnable example.
 
 ### Output
 
-When discovery ends in a genuine confirm, the result JSON gets an extra `rampVerification` object
-absent from AIMD runs and from CHOP runs that only hit the safety cap:
+When discovery ends in a genuine confirm *and* nothing during discovery ever contradicted anything
+else, the result JSON gets an extra `rampVerification` object — absent from AIMD runs, from CHOP
+runs that only hit the safety cap, and from CHOP runs that flagged `isNonMonotonic()` at any point
+(see "Trial finding" below — a contradicted discovery is withheld entirely rather than reported as
+a specific, possibly-unreproducible rate):
 
 ```json
 "rampVerification": {
@@ -138,9 +142,10 @@ absent from AIMD runs and from CHOP runs that only hit the safety cap:
 }
 ```
 
-`startEpochMillis`/`endEpochMillis` bracket the *final* confirmation hold specifically — useful for
-attributing resource usage (CPU/memory) to the verified rate rather than the whole warmup +
-discovery + measurement run.
+`nonMonotonic` is therefore always `false` whenever this object is present (kept in the schema for
+stability rather than removed). `startEpochMillis`/`endEpochMillis` bracket the *final* confirmation
+hold specifically — useful for attributing resource usage (CPU/memory) to the verified rate rather
+than the whole warmup + discovery + measurement run.
 
 ### Known limitation
 
@@ -157,6 +162,84 @@ like a real capacity problem, permanently capping `hi` far below the system's ac
 bad early reading, and chop would only ever search inside the too-small bracket it produced, with
 no way to recover (unlike AIMD, which just keeps retrying for the rest of the test). `rampSettleSeconds`
 and requiring bracket's clean readings to hold (`rampBracketHoldSeconds`) fixed that specific case.
+
+### Trial finding: `rampMaxBacklogSeconds` can defeat its own backlog check at high rates
+
+Found running the consuming harness's (`conduktor/benchmarks`) AKS integration test against this
+branch's image, 2026-07-24. Reported here (not just as harness-side feedback) because it looks
+like a real gap in this algorithm, independent of the harness.
+
+**Setup**: AKS, `representative` infra preset (dedicated node pools, node-isolated brokers/gateway/
+workers), direct-to-Kafka (no gateway), 1 topic / 100 partitions / 100-byte messages, single
+producer/consumer. Two loads on the same topology for comparison: `rampAlgorithm: AIMD` (default)
+and `rampAlgorithm: CHOP` with:
+
+```yaml
+rampStartRate: 20000
+rampMaxBacklogSeconds: 1.0
+rampBracketHoldSeconds: 30
+rampHoldSeconds: 60
+rampConvergenceTolerance: 0.05
+rampMaxDiscoveryMinutes: 12
+testDurationMinutes: 15
+```
+
+(`rampBracketPeriodSeconds` and `rampSettleSeconds` left at their defaults, 3s and 30s.)
+
+**Result**: CHOP reported a genuine confirm —
+
+```
+WARN  WorkloadGenerator - Ramp discovery detected non-monotonic backlog behavior --
+      1800000.0 msg/s may not reproduce reliably; consider treating it as a band rather
+      than an exact figure.
+INFO  WorkloadGenerator - ----- Ramp discovery (CHOP) complete: 1800000.0 msg/s -----
+```
+
+`rampVerification.rate = 1800000.0`, `nonMonotonic = true`. That is not a plausible sustainable
+rate for this setup: **AIMD topped out at ~28,000 msg/s** on the identical topology/hardware in
+the same run (a separate trial on the same cluster shape previously saw AIMD peak ~65,000), and
+CHOP's own subsequent fixed-rate measurement window — running at the "confirmed" 1,800,000 target —
+only *achieved* ~1.3-1.5M, i.e. it couldn't even sustain the number it had just certified. Off by
+roughly two orders of magnitude from anything AIMD ever observed.
+
+**Diagnosis**: `rampMaxBacklogSeconds` scales the backlog tolerance *with the candidate rate*
+(`limit = currentRate * rampMaxBacklogSeconds`) — correct in spirit (fixed-count limits are loose
+at high rates, tight at low ones), but nothing bounds how large that limit gets as bracket's
+exponential doubling runs away. At a 1,000,000 msg/s candidate, `rampMaxBacklogSeconds: 1.0` means
+tolerating **1,000,000 messages** of backlog before flagging a problem — by that point the check is
+essentially disabled. The bracket phase (or a reopened search) apparently kept finding *some*
+combination of candidates that looked clean under that ballooning tolerance, occasionally
+contradicting each other (hence `nonMonotonic: true` — the flag did its job and caught that
+something was wrong), but the search still landed on and reported a concrete, confidently-wrong
+number rather than stopping or refusing to confirm.
+
+**Suggested follow-ups** (not implemented here — flagging for whoever picks this up):
+- Cap the rate-relative limit with an absolute ceiling too, e.g.
+`min(currentRate * rampMaxBacklogSeconds, someAbsoluteMax)`, so it can't grow unbounded during
+exponential bracket doubling.
+- Consider treating `nonMonotonic: true` as more than an advisory flag — e.g. refusing to attach
+`rampVerification` at all (or attaching a band instead of a point value) when the discovery that
+produced it was internally contradictory, rather than reporting a specific rate that the
+docstring itself says "may not reproduce reliably."
+- Document a **guideline value** for `rampMaxBacklogSeconds` (this trial used 1.0s, which in
+hindsight is far too generous once compounded with rate — something like 0.05-0.1s is probably
+closer to what fixed-count defaults were achieving at realistic rates) rather than leaving the
+right order of magnitude to guesswork.
+
+Harness-side note (not a CHOP issue): the resource-sampling integration this trial was validating
+worked correctly regardless — a `rampVerification`-scoped Prometheus capture was produced
+alongside the whole-job one, with sensible (lower) CPU/mem numbers in the narrower window. The bad
+data here is a confirmed *rate*, not a broken capture mechanism.
+
+**Fixed**: both suggested follow-ups above are now implemented.
+`rampMaxBacklogCeiling` (default 100000) caps the relative limit so it can't grow unbounded as
+bracket's exponential doubling runs away, and `isNonMonotonic()` is no longer purely advisory —
+`rampVerification` is now withheld entirely (not attached, at any rate) whenever discovery flagged
+non-monotonic behavior anywhere, confirmed or not, rather than reporting a specific number the log
+message itself admits may not reproduce. The third suggestion (a documented guideline value for `rampMaxBacklogSeconds` itself) remains
+open — this trial used `1.0`, and while the ceiling now guards against that value running away, it
+was still a somewhat arbitrary starting point rather than one derived from what fixed-count limits
+were actually achieving at realistic rates.
 
 ## Which to use
 

--- a/benchmark-framework/RATE_FINDING.md
+++ b/benchmark-framework/RATE_FINDING.md
@@ -1,0 +1,146 @@
+# Rate finding (`producerRate: 0`)
+
+Setting `producerRate: 0` in a workload YAML tells the benchmark to discover the maximum
+sustainable producer rate itself, instead of running at a fixed rate you supply. Two algorithms
+implement this, selected via the `rampAlgorithm` workload field:
+
+|                                       |  `rampAlgorithm: AIMD` (default)  |       `rampAlgorithm: CHOP`        |
+|---------------------------------------|-----------------------------------|------------------------------------|
+| Status                                | Original/mainline behavior        | Opt-in addition                    |
+| Behavior                              | Continuous, never stops adjusting | Converges, then holds a fixed rate |
+| Configuration                         | Environment variables only        | Workload YAML fields               |
+| Verifies the rate before reporting it | No                                | Yes (hold-and-confirm)             |
+| Detects an unreliable/flaky result    | No                                | Yes (`isNonMonotonic`)             |
+| Result attached to output JSON        | No                                | `rampVerification` object          |
+
+Neither algorithm's mechanics were documented anywhere before this file — there's no README or
+`docs/` entry for either. This is that documentation.
+
+## AIMD (`RateController.java`, `WorkloadGenerator.findMaximumSustainableRate()`)
+
+This is the original discovery mechanism and remains the default; nothing about it changed when
+`CHOP` was added.
+
+When `producerRate == 0` and `rampAlgorithm == AIMD` (or unset), `WorkloadGenerator.run()` starts
+`targetPublishRate` at a hardcoded `10000` msg/s and spawns a **background thread** that runs
+`findMaximumSustainableRate()` for the rest of the test — including through warmup and the entire
+measurement window, only stopping when the test itself ends.
+
+That thread loops every `controlPeriodMillis = 3000` (hardcoded, 3 seconds):
+
+1. Read cumulative `messagesSent`/`messagesReceived` from the worker.
+2. Call `RateController.nextRate(currentRate, periodNanos, sent, received)`.
+3. Apply the returned rate immediately via `worker.adjustPublishRate(...)`.
+
+`RateController` implements the actual control logic — an additive-increase/multiplicative-decrease
+(AIMD) style controller built around a `rampingFactor`:
+
+- Compute `expected` throughput for the period from the current rate, and compare it against what
+  was actually `published`/`received`.
+- If `receiveBacklog` (`totalPublished - totalReceived`) or `publishBacklog`
+  (`expected - published`) exceeds a limit → **ramp down**: halve `rampingFactor` (floored at
+  `minRampingFactor`) and return a reduced rate computed from actual throughput.
+- Otherwise → **ramp up**: double `rampingFactor` (capped at `maxRampingFactor`) and return
+  `rate + rate * rampingFactor` — exponential growth as long as no backlog builds up.
+
+Its tuning knobs are **environment variables only** — there is no way to set them per-workload in
+YAML:
+
+|         Env var         | Default |                             Meaning                              |
+|-------------------------|---------|------------------------------------------------------------------|
+| `PUBLISH_BACKLOG_LIMIT` | 1000    | Messages of publish-side lag tolerated before ramping down       |
+| `RECEIVE_BACKLOG_LIMIT` | 1000    | Messages of consumer lag tolerated before ramping down           |
+| `MIN_RAMPING_FACTOR`    | 0.01    | Floor for the ramping factor after repeated ramp-downs           |
+| `MAX_RAMPING_FACTOR`    | 1.0     | Ceiling for the ramping factor (i.e. max rate growth per period) |
+
+**What this means in practice**: AIMD never "finishes" and never claims the number it's currently
+using is verified. Whatever rate happens to be in effect when the measurement window's stats are
+collected is what gets reported — it could be mid-ramp-up, mid-ramp-down, or oscillating. There's
+no equivalent of "this rate was confirmed sustainable"; there's only "this is what the reactive
+loop was doing at the moment we looked."
+
+## CHOP (`RampRateFinder.java`, `WorkloadGenerator.runChopDiscovery()`)
+
+CHOP exists because AIMD's constant oscillation makes its answer hard to reproduce: a rate that
+looked fine for one 3-second window isn't necessarily one you can safely run for a full test.
+Opt in with `rampAlgorithm: CHOP` in the workload YAML.
+
+Unlike AIMD, CHOP runs to completion **before** warmup starts (`runChopDiscovery()` blocks
+`WorkloadGenerator.run()`), then the measurement window runs at the fixed rate CHOP converged on.
+
+### Algorithm
+
+1. **Bracket** — starting at `rampStartRate` (default 10000), double the rate every
+   `rampBracketPeriodSeconds` (default 3s) while backlog stays clean. The first breach sets a
+   known-bad `hi`; the last clean rate is the known-good `lo`. (Handles the reverse case too — if
+   even the start rate is already overloaded, it halves downward until it finds a clean `lo`.)
+2. **Chop** — binary search the `[lo, hi]` bracket. Each candidate is held for `rampHoldSeconds`
+   (default 30s), not just glanced at — a single 3s reactive snapshot (AIMD's approach) isn't
+   enough to know a rate actually holds.
+3. **Confirm** — once a candidate holds clean within `rampConvergenceTolerance` (default 5%), it
+   isn't accepted immediately. It must pass `rampConfirmationHolds` (default 1) additional,
+   consecutive clean holds at the *same* rate before being accepted. This is what makes "verified"
+   mean something more than "passed once."
+4. **Reopen on a failed confirmation** — if a confirmation hold fails (the rate looked fine, then
+   didn't hold up), CHOP does not accept it anyway. It reopens the search: tightens `hi` to the
+   failed rate, and falls back to the highest rate already *observed* to pass below it (never a
+   blind guess — `lo` is always sourced from a real, recorded pass) as the new `lo`, then restarts
+   the hold-and-confirm cycle from there.
+5. **Non-monotonic flag** — every tested `(rate, passed/failed)` outcome is recorded. If a later
+   verdict ever contradicts an earlier one (e.g. a lower rate fails after a higher one already
+   passed), `isNonMonotonic()` is set and stays set for the rest of the run, even if the reopened
+   search goes on to confirm cleanly. It's a signal that the system showed unstable behavior
+   *somewhere* during discovery, so the final number may not reproduce as cleanly as a clean run
+   would.
+6. **Safety cap** — `rampMaxDiscoveryMinutes` (default 10) bounds total discovery time; if hit,
+   discovery stops and reports the best confirmed-or-passed `lo` found so far.
+
+### Configuration (workload YAML fields, all optional, only apply when `producerRate: 0`)
+
+|           Field            |                Default                 |                                                                                                                                               Applies to                                                                                                                                               |
+|----------------------------|----------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `rampAlgorithm`            | `AIMD`                                 | Selects the algorithm                                                                                                                                                                                                                                                                                  |
+| `rampStartRate`            | 10000                                  | Both                                                                                                                                                                                                                                                                                                   |
+| `rampPublishBacklogLimit`  | env `PUBLISH_BACKLOG_LIMIT`, else 1000 | Both                                                                                                                                                                                                                                                                                                   |
+| `rampReceiveBacklogLimit`  | env `RECEIVE_BACKLOG_LIMIT`, else 1000 | Both                                                                                                                                                                                                                                                                                                   |
+| `rampMaxBacklogSeconds`    | unset                                  | CHOP only — when set, replaces the two fields above with a limit that scales with the candidate rate (`limit = currentRate * rampMaxBacklogSeconds`), so the check is equally strict at every rate tried during bracket's exponential range instead of being loose at high rates and tight at low ones |
+| `rampBracketPeriodSeconds` | 3                                      | CHOP only                                                                                                                                                                                                                                                                                              |
+| `rampHoldSeconds`          | 30                                     | CHOP only                                                                                                                                                                                                                                                                                              |
+| `rampConfirmationHolds`    | 1                                      | CHOP only                                                                                                                                                                                                                                                                                              |
+| `rampConvergenceTolerance` | 0.05                                   | CHOP only                                                                                                                                                                                                                                                                                              |
+| `rampMaxDiscoveryMinutes`  | 10                                     | CHOP only                                                                                                                                                                                                                                                                                              |
+
+See `workloads/max-rate-chop-1-topic-100-partitions-100b.yaml` for a runnable example.
+
+### Output
+
+When discovery ends in a genuine confirm, the result JSON gets an extra `rampVerification` object
+absent from AIMD runs and from CHOP runs that only hit the safety cap:
+
+```json
+"rampVerification": {
+  "rate": 46000.0,
+  "startEpochMillis": 1784817684100,
+  "endEpochMillis": 1784817690849,
+  "nonMonotonic": false
+}
+```
+
+`startEpochMillis`/`endEpochMillis` bracket the *final* confirmation hold specifically — useful for
+attributing resource usage (CPU/memory) to the verified rate rather than the whole warmup +
+discovery + measurement run.
+
+### Known limitation
+
+Bracket phase deliberately overshoots (2x) past the real limit before backing off, to find `hi`.
+That overshoot's fallout (backlog, GC pressure, broker load) isn't drained before the first chop
+candidate starts its hold clock — so an early chop reading can still be affected by bracket's own
+overshoot rather than reflecting steady state at that candidate alone. Not yet addressed; would
+need an explicit drain/settle sub-phase between bracket and chop.
+
+## Which to use
+
+AIMD if you just want *a* number and don't care whether it's reproducible in a follow-up run at a
+fixed rate. CHOP if you intend to take the discovered rate and actually rely on it — e.g. feeding
+it into a fixed-`producerRate` workload later, or attributing resource cost to "the rate we
+verified" rather than an average blurred across a whole oscillating test.

--- a/benchmark-framework/RATE_FINDING.md
+++ b/benchmark-framework/RATE_FINDING.md
@@ -107,21 +107,22 @@ Unlike AIMD, CHOP runs to completion **before** warmup starts (`runChopDiscovery
 
 ### Configuration (workload YAML fields, all optional, only apply when `producerRate: 0`)
 
-|           Field            |                Default                 |                                                                                                                                                             Applies to                                                                                                                                                             |
-|----------------------------|----------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `rampAlgorithm`            | `AIMD`                                 | Selects the algorithm                                                                                                                                                                                                                                                                                                              |
-| `rampStartRate`            | 10000                                  | Both                                                                                                                                                                                                                                                                                                                               |
-| `rampPublishBacklogLimit`  | env `PUBLISH_BACKLOG_LIMIT`, else 1000 | Both                                                                                                                                                                                                                                                                                                                               |
-| `rampReceiveBacklogLimit`  | env `RECEIVE_BACKLOG_LIMIT`, else 1000 | Both                                                                                                                                                                                                                                                                                                                               |
-| `rampMaxBacklogSeconds`    | unset                                  | CHOP only — when set, replaces the two fields above with a limit that scales with the candidate rate (`limit = min(currentRate * rampMaxBacklogSeconds, rampMaxBacklogCeiling)`), so the check is equally strict at every rate tried during bracket's exponential range instead of being loose at high rates and tight at low ones |
-| `rampMaxBacklogCeiling`    | 100000                                 | CHOP only — hard cap (messages) on the limit `rampMaxBacklogSeconds` computes; only meaningful when `rampMaxBacklogSeconds` is set (see "Trial finding" below for why this exists)                                                                                                                                                 |
-| `rampBracketPeriodSeconds` | 3                                      | CHOP only — poll cadence, not a hold duration                                                                                                                                                                                                                                                                                      |
-| `rampSettleSeconds`        | 30                                     | CHOP only — grace period at start before backlog counts at all                                                                                                                                                                                                                                                                     |
-| `rampBracketHoldSeconds`   | resolved `rampHoldSeconds`             | CHOP only — how long a bracket candidate must hold clean; shorten independently once you trust bracket's coarser candidates need less scrutiny                                                                                                                                                                                     |
-| `rampHoldSeconds`          | 30                                     | CHOP only — how long a chop candidate must hold clean                                                                                                                                                                                                                                                                              |
-| `rampConfirmationHolds`    | 1                                      | CHOP only                                                                                                                                                                                                                                                                                                                          |
-| `rampConvergenceTolerance` | 0.05                                   | CHOP only                                                                                                                                                                                                                                                                                                                          |
-| `rampMaxDiscoveryMinutes`  | 10                                     | CHOP only                                                                                                                                                                                                                                                                                                                          |
+|           Field            |                Default                 |                                                                                                                                                                        Applies to                                                                                                                                                                         |
+|----------------------------|----------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `rampAlgorithm`            | `AIMD`                                 | Selects the algorithm                                                                                                                                                                                                                                                                                                                                     |
+| `rampStartRate`            | 10000                                  | Both                                                                                                                                                                                                                                                                                                                                                      |
+| `rampPublishBacklogLimit`  | env `PUBLISH_BACKLOG_LIMIT`, else 1000 | Both                                                                                                                                                                                                                                                                                                                                                      |
+| `rampReceiveBacklogLimit`  | env `RECEIVE_BACKLOG_LIMIT`, else 1000 | Both                                                                                                                                                                                                                                                                                                                                                      |
+| `rampMaxBacklogSeconds`    | unset                                  | CHOP only — when set, replaces the two fields above with a limit that scales with the candidate rate (`limit = clamp(currentRate * rampMaxBacklogSeconds, rampMaxBacklogFloor, rampMaxBacklogCeiling)`), so the check is equally strict at every rate tried during bracket's exponential range instead of being loose at high rates and tight at low ones |
+| `rampMaxBacklogFloor`      | 1000                                   | CHOP only — hard floor (messages) on the limit `rampMaxBacklogSeconds` computes, matching the old fixed-count default so the relative check can never become stricter than a fixed-count check would have been at any rate; only meaningful when `rampMaxBacklogSeconds` is set (see "Trial finding" below)                                               |
+| `rampMaxBacklogCeiling`    | 100000                                 | CHOP only — hard cap (messages) on the same limit; only meaningful when `rampMaxBacklogSeconds` is set (see "Trial finding" below for why this exists)                                                                                                                                                                                                    |
+| `rampBracketPeriodSeconds` | 3                                      | CHOP only — poll cadence, not a hold duration                                                                                                                                                                                                                                                                                                             |
+| `rampSettleSeconds`        | 30                                     | CHOP only — grace period at start before backlog counts at all                                                                                                                                                                                                                                                                                            |
+| `rampBracketHoldSeconds`   | resolved `rampHoldSeconds`             | CHOP only — how long a bracket candidate must hold clean; shorten independently once you trust bracket's coarser candidates need less scrutiny                                                                                                                                                                                                            |
+| `rampHoldSeconds`          | 30                                     | CHOP only — how long a chop candidate must hold clean                                                                                                                                                                                                                                                                                                     |
+| `rampConfirmationHolds`    | 1                                      | CHOP only                                                                                                                                                                                                                                                                                                                                                 |
+| `rampConvergenceTolerance` | 0.05                                   | CHOP only                                                                                                                                                                                                                                                                                                                                                 |
+| `rampMaxDiscoveryMinutes`  | 10                                     | CHOP only                                                                                                                                                                                                                                                                                                                                                 |
 
 See `workloads/max-rate-chop-1-topic-100-partitions-100b.yaml` for a runnable example.
 
@@ -240,6 +241,70 @@ message itself admits may not reproduce. The third suggestion (a documented guid
 open — this trial used `1.0`, and while the ceiling now guards against that value running away, it
 was still a somewhat arbitrary starting point rather than one derived from what fixed-count limits
 were actually achieving at realistic rates.
+
+### Trial finding: with no floor, the same tolerance can also spiral *down* to a trivial rate
+
+Found re-running the same harness integration test, 2026-07-24, same day. **Correction**: this
+was originally reported as confirmed running the `rampMaxBacklogCeiling` fix (`7f97593`) based on
+CI-completion timing alone. On closer inspection that's unconfirmed either way: the image was
+published to the registry 26 seconds before this run's first cell (`aimd`, sharing the same
+dedicated worker nodes `chop` later reused) had already logged "Starting benchmark" — too tight a
+window for a fresh multi-hundred-MB pull to complete, and `imagePullPolicy: IfNotPresent` means
+whatever `aimd` cached first is what `chop` would have reused regardless of what the registry tag
+pointed to by then. Genuinely unknown which version ran here. Doesn't change the finding below,
+though — the missing floor is a gap in the rate-relative computation itself, present with or
+without the ceiling fix.
+
+**Setup**: same as above, but `rampMaxBacklogSeconds` tightened from `1.0` to `0.1` (in direct
+response to the previous finding) — everything else unchanged (`rampStartRate: 20000`,
+`rampBracketHoldSeconds: 30`, `rampHoldSeconds: 60`, `rampConvergenceTolerance: 0.05`,
+`rampMaxDiscoveryMinutes: 12`, `testDurationMinutes: 15`).
+
+**Result**: CHOP reported a genuine confirm — `rampVerification.rate = 0.9155273437500011`,
+`nonMonotonic = false`. Discovery took ~7m39s (well inside budget), and the final confirmation
+hold was a clean, uncontested 60s (`2026-07-24T10:53:59Z -> 2026-07-24T10:54:59Z`). The
+measurement phase then ran at that ~1 msg/s rate for the full 15 minutes with **zero backlog and
+~2.5ms latency throughout** — i.e. the system was never remotely stressed at this rate. AIMD (same
+run, same topology) had no trouble sustaining tens of thousands of msg/s. A ~1 msg/s "sustainable
+rate" for a 1-topic/100-partition Kafka cluster is not a real capacity limit; something in
+discovery talked itself down to a trivial number and then confirmed it cleanly, with no
+contradiction to flag.
+
+**Diagnosis (hypothesis, not confirmed against the source)**: `rampMaxBacklogSeconds` scales the
+tolerance down along with the candidate rate just as much as it scales it up — there's a ceiling
+now, but no floor. If bracket's first candidate (or an early one) trips a false failure for any
+reason (a moment of real jitter, a coincidental timing artifact — hard to say without instrumenting
+the actual hold windows), the halving path that follows makes the *next* candidate's tolerance
+*smaller* in direct proportion to the *lower* rate being tested. That's the wrong direction for a
+recovery mechanism: each step down make the check stricter, not more lenient, so a single early
+false-positive can cascade all the way to a floor near zero rather than settling once real headroom
+appears. The old fixed-count default (1000 messages, rate-independent) didn't have this failure
+mode — it got *easier* to pass as the candidate rate fell, providing a natural backstop.
+
+**Suggested follow-up**: give `rampMaxBacklogSeconds` a floor symmetric to the new ceiling, e.g.
+`limit = clamp(currentRate * rampMaxBacklogSeconds, rampMaxBacklogFloor, rampMaxBacklogCeiling)`,
+with a sensible default floor (perhaps the old fixed-count default, 1000) so the relative check
+can't become stricter than a fixed-count check would have been at any rate, however low the search
+has already fallen.
+
+Harness-side note (not a CHOP issue, same as above): `chop-verify.metrics.json` was produced again
+alongside the whole-job capture, confirming the resource-sampling integration is unaffected by
+which rate CHOP happens to land on — it faithfully samples whatever window `rampVerification`
+reports, correct data or not.
+
+**Reproduced, same day**: reran the identical setup on a *freshly provisioned* cluster (new node
+pools, so no `imagePullPolicy: IfNotPresent` caching ambiguity this time — this run unambiguously
+pulled whatever the `pr-19` tag currently resolves to). Result: `rampVerification.rate =
+0.9155273438210543` — matching the original run's `0.9155273437500011` to **7 significant
+figures**, `nonMonotonic: false` again, identical flatline-at-1-msg/s measurement pattern. This
+isn't environmental flakiness; it's a deterministic outcome of the same starting conditions
+(`rampStartRate: 20000`, `rampMaxBacklogSeconds: 0.1`) hitting the same missing-floor gap every
+time. Confirms the diagnosis above rather than just being a one-off fluke.
+
+**Fixed**: `rampMaxBacklogFloor` (default 1000, matching the old fixed-count default per the
+suggested follow-up above) now clamps the same limit from below, symmetric to
+`rampMaxBacklogCeiling`. The relative check can no longer become stricter than a fixed-count check
+would have been at any rate, however far the search has already fallen.
 
 ## Which to use
 

--- a/benchmark-framework/RATE_FINDING.md
+++ b/benchmark-framework/RATE_FINDING.md
@@ -70,30 +70,40 @@ Unlike AIMD, CHOP runs to completion **before** warmup starts (`runChopDiscovery
 
 ### Algorithm
 
-1. **Bracket** — starting at `rampStartRate` (default 10000), double the rate every
-   `rampBracketPeriodSeconds` (default 3s) while backlog stays clean. The first breach sets a
-   known-bad `hi`; the last clean rate is the known-good `lo`. (Handles the reverse case too — if
-   even the start rate is already overloaded, it halves downward until it finds a clean `lo`.)
-2. **Chop** — binary search the `[lo, hi]` bracket. Each candidate is held for `rampHoldSeconds`
-   (default 30s), not just glanced at — a single 3s reactive snapshot (AIMD's approach) isn't
-   enough to know a rate actually holds.
-3. **Confirm** — once a candidate holds clean within `rampConvergenceTolerance` (default 5%), it
+1. **Settle** — run at `rampStartRate` for `rampSettleSeconds` (default 30s) before evaluating
+   backlog *at all*. Right after `startLoad()`, a consumer-group rebalance tail or producer
+   connection warm-up can still be settling; without this grace period, that transient gets
+   evaluated exactly like a real capacity problem and can permanently cap the search too low (see
+   "Known limitation" below — this is the fix for it).
+2. **Bracket** — starting at `rampStartRate`, double the rate every poll while backlog stays
+   clean. A breach is immediately actionable (fail-fast, no need to hold out a rate that's already
+   failing) and sets a known-bad `hi`; a clean reading must hold for `rampBracketHoldSeconds`
+   (defaults to the resolved `rampHoldSeconds` — i.e. bracket is exactly as rigorous as chop unless
+   you deliberately shorten it) before being accepted as the known-good `lo`. (Handles the reverse
+   case too — if even the start rate is already overloaded, it halves downward until it finds a
+   clean `lo`.)
+3. **Chop** — binary search the `[lo, hi]` bracket. Each candidate is held for `rampHoldSeconds`
+   (default 30s), not just glanced at — a single reactive snapshot (AIMD's approach) isn't enough
+   to know a rate actually holds.
+4. **Confirm** — once a candidate holds clean within `rampConvergenceTolerance` (default 5%), it
    isn't accepted immediately. It must pass `rampConfirmationHolds` (default 1) additional,
    consecutive clean holds at the *same* rate before being accepted. This is what makes "verified"
    mean something more than "passed once."
-4. **Reopen on a failed confirmation** — if a confirmation hold fails (the rate looked fine, then
+5. **Reopen on a failed confirmation** — if a confirmation hold fails (the rate looked fine, then
    didn't hold up), CHOP does not accept it anyway. It reopens the search: tightens `hi` to the
    failed rate, and falls back to the highest rate already *observed* to pass below it (never a
    blind guess — `lo` is always sourced from a real, recorded pass) as the new `lo`, then restarts
    the hold-and-confirm cycle from there.
-5. **Non-monotonic flag** — every tested `(rate, passed/failed)` outcome is recorded. If a later
+6. **Non-monotonic flag** — every tested `(rate, passed/failed)` outcome is recorded. If a later
    verdict ever contradicts an earlier one (e.g. a lower rate fails after a higher one already
    passed), `isNonMonotonic()` is set and stays set for the rest of the run, even if the reopened
    search goes on to confirm cleanly. It's a signal that the system showed unstable behavior
    *somewhere* during discovery, so the final number may not reproduce as cleanly as a clean run
    would.
-6. **Safety cap** — `rampMaxDiscoveryMinutes` (default 10) bounds total discovery time; if hit,
-   discovery stops and reports the best confirmed-or-passed `lo` found so far.
+7. **Safety cap** — `rampMaxDiscoveryMinutes` (default 10) bounds total discovery time; if hit,
+   discovery stops and reports the best confirmed-or-passed `lo` found so far. Bear in mind the
+   settle period and every bracket/chop hold all draw from this same budget — with generous hold
+   settings, raise this alongside them.
 
 ### Configuration (workload YAML fields, all optional, only apply when `producerRate: 0`)
 
@@ -104,8 +114,10 @@ Unlike AIMD, CHOP runs to completion **before** warmup starts (`runChopDiscovery
 | `rampPublishBacklogLimit`  | env `PUBLISH_BACKLOG_LIMIT`, else 1000 | Both                                                                                                                                                                                                                                                                                                   |
 | `rampReceiveBacklogLimit`  | env `RECEIVE_BACKLOG_LIMIT`, else 1000 | Both                                                                                                                                                                                                                                                                                                   |
 | `rampMaxBacklogSeconds`    | unset                                  | CHOP only — when set, replaces the two fields above with a limit that scales with the candidate rate (`limit = currentRate * rampMaxBacklogSeconds`), so the check is equally strict at every rate tried during bracket's exponential range instead of being loose at high rates and tight at low ones |
-| `rampBracketPeriodSeconds` | 3                                      | CHOP only                                                                                                                                                                                                                                                                                              |
-| `rampHoldSeconds`          | 30                                     | CHOP only                                                                                                                                                                                                                                                                                              |
+| `rampBracketPeriodSeconds` | 3                                      | CHOP only — poll cadence, not a hold duration                                                                                                                                                                                                                                                          |
+| `rampSettleSeconds`        | 30                                     | CHOP only — grace period at start before backlog counts at all                                                                                                                                                                                                                                         |
+| `rampBracketHoldSeconds`   | resolved `rampHoldSeconds`             | CHOP only — how long a bracket candidate must hold clean; shorten independently once you trust bracket's coarser candidates need less scrutiny                                                                                                                                                         |
+| `rampHoldSeconds`          | 30                                     | CHOP only — how long a chop candidate must hold clean                                                                                                                                                                                                                                                  |
 | `rampConfirmationHolds`    | 1                                      | CHOP only                                                                                                                                                                                                                                                                                              |
 | `rampConvergenceTolerance` | 0.05                                   | CHOP only                                                                                                                                                                                                                                                                                              |
 | `rampMaxDiscoveryMinutes`  | 10                                     | CHOP only                                                                                                                                                                                                                                                                                              |
@@ -136,7 +148,15 @@ Bracket phase deliberately overshoots (2x) past the real limit before backing of
 That overshoot's fallout (backlog, GC pressure, broker load) isn't drained before the first chop
 candidate starts its hold clock — so an early chop reading can still be affected by bracket's own
 overshoot rather than reflecting steady state at that candidate alone. Not yet addressed; would
-need an explicit drain/settle sub-phase between bracket and chop.
+need an explicit drain sub-phase between bracket and chop (distinct from `rampSettleSeconds`
+above, which only runs once, before bracket starts).
+
+This used to also apply to the very *first* bracket reading: a consumer-group rebalance tail or
+producer connection warm-up still settling right after `startLoad()` could be evaluated exactly
+like a real capacity problem, permanently capping `hi` far below the system's actual ceiling — one
+bad early reading, and chop would only ever search inside the too-small bracket it produced, with
+no way to recover (unlike AIMD, which just keeps retrying for the rest of the test). `rampSettleSeconds`
+and requiring bracket's clean readings to hold (`rampBracketHoldSeconds`) fixed that specific case.
 
 ## Which to use
 

--- a/benchmark-framework/pom.xml
+++ b/benchmark-framework/pom.xml
@@ -27,6 +27,7 @@
 
     <properties>
         <jetty.version>9.4.42.v20210604</jetty.version>
+        <testcontainers.version>1.21.3</testcontainers.version>
     </properties>
 
     <dependencies>
@@ -185,6 +186,21 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Integration tests only (failsafe *IT): drive the real CHOP discovery loop against a
+             throwaway Kafka broker. driver-kafka + kafka-clients are already on the compile
+             classpath above, so Testcontainers is the only addition. -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>kafka</artifactId>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/RampAlgorithm.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/RampAlgorithm.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openmessaging.benchmark;
+
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+
+/** Selects which algorithm discovers the max sustainable rate when producerRate == 0. */
+public enum RampAlgorithm {
+    /** Continuous backlog-reactive AIMD control that runs for the whole test duration. */
+    @JsonEnumDefaultValue
+    AIMD,
+
+    /** Bracket the knee, then binary-chop with a hold-and-verify step at each candidate. */
+    CHOP,
+}

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/RampAlgorithm.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/RampAlgorithm.java
@@ -13,6 +13,7 @@
  */
 package io.openmessaging.benchmark;
 
+
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 
 /** Selects which algorithm discovers the max sustainable rate when producerRate == 0. */

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/RampRateFinder.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/RampRateFinder.java
@@ -50,6 +50,7 @@ class RampRateFinder {
     private final long publishBacklogLimit;
     private final long receiveBacklogLimit;
     private final Double maxBacklogSeconds;
+    private final long maxBacklogFloor;
     private final long maxBacklogCeiling;
     private final long settleNanos;
     private final long bracketHoldNanos;
@@ -103,6 +104,8 @@ class RampRateFinder {
                         ? workload.rampReceiveBacklogLimit.longValue()
                         : Env.getLong("RECEIVE_BACKLOG_LIMIT", 1_000);
         this.maxBacklogSeconds = workload.rampMaxBacklogSeconds;
+        this.maxBacklogFloor =
+                workload.rampMaxBacklogFloor != null ? workload.rampMaxBacklogFloor.longValue() : 1_000L;
         this.maxBacklogCeiling =
                 workload.rampMaxBacklogCeiling != null
                         ? workload.rampMaxBacklogCeiling.longValue()
@@ -163,13 +166,20 @@ class RampRateFinder {
         if (maxBacklogSeconds != null) {
             // A limit that scales with the candidate rate, so the predicate is equally strict
             // at every rate tested during bracket's exponential range -- a fixed message count
-            // is comparatively loose at high rates and comparatively tight at low ones. Capped by
-            // maxBacklogCeiling so the tolerance itself can't grow unbounded as bracket's
+            // is comparatively loose at high rates and comparatively tight at low ones. Clamped
+            // at both ends: maxBacklogCeiling stops the tolerance growing unbounded as bracket's
             // exponential doubling runs away past the real ceiling (a real incident: at a
             // 1,000,000+ msg/s candidate, an uncapped 1.0s tolerance meant a million messages of
             // backlog still counted as "clean," and the search reported a two-orders-of-magnitude
-            // wrong rate as confirmed).
-            double limit = Math.min(currentRate * maxBacklogSeconds, (double) maxBacklogCeiling);
+            // wrong rate as confirmed). maxBacklogFloor stops the opposite: without it, a single
+            // early false failure halves the rate and, in the same stroke, halves the tolerance --
+            // the wrong direction for a recovery mechanism -- letting one bad reading cascade all
+            // the way down to a near-zero "confirmed" rate (also a real incident, reproduced
+            // deterministically twice on the same starting conditions).
+            double limit =
+                    Math.max(
+                            maxBacklogFloor,
+                            Math.min(currentRate * maxBacklogSeconds, (double) maxBacklogCeiling));
             backlogExceeded = receiveBacklog > limit || publishBacklog > limit;
         } else {
             backlogExceeded =

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/RampRateFinder.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/RampRateFinder.java
@@ -50,6 +50,7 @@ class RampRateFinder {
     private final long publishBacklogLimit;
     private final long receiveBacklogLimit;
     private final Double maxBacklogSeconds;
+    private final long maxBacklogCeiling;
     private final long settleNanos;
     private final long bracketHoldNanos;
     private final long holdNanos;
@@ -102,6 +103,10 @@ class RampRateFinder {
                         ? workload.rampReceiveBacklogLimit.longValue()
                         : Env.getLong("RECEIVE_BACKLOG_LIMIT", 1_000);
         this.maxBacklogSeconds = workload.rampMaxBacklogSeconds;
+        this.maxBacklogCeiling =
+                workload.rampMaxBacklogCeiling != null
+                        ? workload.rampMaxBacklogCeiling.longValue()
+                        : 100_000L;
         int settleSeconds =
                 workload.rampSettleSeconds != null ? workload.rampSettleSeconds.intValue() : 30;
         this.settleNanos = SECONDS.toNanos(settleSeconds);
@@ -158,8 +163,13 @@ class RampRateFinder {
         if (maxBacklogSeconds != null) {
             // A limit that scales with the candidate rate, so the predicate is equally strict
             // at every rate tested during bracket's exponential range -- a fixed message count
-            // is comparatively loose at high rates and comparatively tight at low ones.
-            double limit = currentRate * maxBacklogSeconds;
+            // is comparatively loose at high rates and comparatively tight at low ones. Capped by
+            // maxBacklogCeiling so the tolerance itself can't grow unbounded as bracket's
+            // exponential doubling runs away past the real ceiling (a real incident: at a
+            // 1,000,000+ msg/s candidate, an uncapped 1.0s tolerance meant a million messages of
+            // backlog still counted as "clean," and the search reported a two-orders-of-magnitude
+            // wrong rate as confirmed).
+            double limit = Math.min(currentRate * maxBacklogSeconds, (double) maxBacklogCeiling);
             backlogExceeded = receiveBacklog > limit || publishBacklog > limit;
         } else {
             backlogExceeded =

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/RampRateFinder.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/RampRateFinder.java
@@ -36,6 +36,11 @@ class RampRateFinder {
     private static final long ONE_SECOND_IN_NANOS = SECONDS.toNanos(1);
     private static final int MAX_BRACKET_ITERATIONS = 20;
 
+    // Used only as a last resort when a failed confirmation has no prior passing rate below it
+    // to fall back on (history should always have one via the bracket phase, but this keeps the
+    // reopened search bounded even in that edge case).
+    private static final double CONFIRMATION_BACKOFF_FACTOR = 0.9;
+
     enum Phase {
         BRACKET,
         CHOP,
@@ -44,9 +49,11 @@ class RampRateFinder {
 
     private final long publishBacklogLimit;
     private final long receiveBacklogLimit;
+    private final Double maxBacklogSeconds;
     private final long holdNanos;
     private final double convergenceTolerance;
     private final long maxDiscoveryNanos;
+    private final int requiredConfirmationHolds;
 
     @Getter(PACKAGE)
     private Phase phase = Phase.BRACKET;
@@ -73,6 +80,7 @@ class RampRateFinder {
     private long elapsedHoldNanos = 0;
     private long totalElapsedNanos = 0;
     private int bracketIterations = 0;
+    private int confirmationHoldsPassed = 0;
 
     private final List<RateVerdict> history = new ArrayList<>();
 
@@ -87,6 +95,7 @@ class RampRateFinder {
                 workload.rampReceiveBacklogLimit != null
                         ? workload.rampReceiveBacklogLimit.longValue()
                         : Env.getLong("RECEIVE_BACKLOG_LIMIT", 1_000);
+        this.maxBacklogSeconds = workload.rampMaxBacklogSeconds;
         int holdSeconds = workload.rampHoldSeconds != null ? workload.rampHoldSeconds.intValue() : 30;
         this.holdNanos = SECONDS.toNanos(holdSeconds);
         this.convergenceTolerance =
@@ -96,6 +105,8 @@ class RampRateFinder {
         int maxDiscoveryMinutes =
                 workload.rampMaxDiscoveryMinutes != null ? workload.rampMaxDiscoveryMinutes.intValue() : 10;
         this.maxDiscoveryNanos = MINUTES.toNanos(maxDiscoveryMinutes);
+        this.requiredConfirmationHolds =
+                workload.rampConfirmationHolds != null ? workload.rampConfirmationHolds.intValue() : 1;
     }
 
     // Advances the state machine given the latest period's counters. Returns true when done.
@@ -116,8 +127,17 @@ class RampRateFinder {
         long publishBacklog = expected - published;
         previousTotalPublished = totalPublished;
 
-        boolean backlogExceeded =
-                receiveBacklog > receiveBacklogLimit || publishBacklog > publishBacklogLimit;
+        boolean backlogExceeded;
+        if (maxBacklogSeconds != null) {
+            // A limit that scales with the candidate rate, so the predicate is equally strict
+            // at every rate tested during bracket's exponential range -- a fixed message count
+            // is comparatively loose at high rates and comparatively tight at low ones.
+            double limit = currentRate * maxBacklogSeconds;
+            backlogExceeded = receiveBacklog > limit || publishBacklog > limit;
+        } else {
+            backlogExceeded =
+                    receiveBacklog > receiveBacklogLimit || publishBacklog > publishBacklogLimit;
+        }
 
         return phase == Phase.BRACKET
                 ? pollBracket(backlogExceeded)
@@ -154,10 +174,17 @@ class RampRateFinder {
         if (backlogExceeded) {
             recordVerdict(currentRate, false);
             if (confirming) {
-                // The converged rate didn't hold on re-check. Stop anyway (best effort) --
-                // isNonMonotonic() is now true so the caller can warn about reproducibility.
-                phase = Phase.DONE;
-                return true;
+                // The candidate didn't hold on re-check, so it's not actually safe -- reopen the
+                // search instead of handing an unverified rate to the caller. Tighten hi to the
+                // rate that just failed, and fall back to the highest rate we've already seen
+                // pass below it (never a blind guess) as the new lo.
+                hi = currentRate;
+                lo = bestKnownPassBelow(hi);
+                confirming = false;
+                confirmationHoldsPassed = 0;
+                elapsedHoldNanos = 0;
+                currentRate = (lo + hi) / 2.0;
+                return false;
             }
             hi = currentRate;
             elapsedHoldNanos = 0;
@@ -179,17 +206,24 @@ class RampRateFinder {
 
         if ((hi - lo) / lo <= convergenceTolerance) {
             if (!confirming) {
-                // Require one more confirmation hold at the same rate before accepting it --
-                // this is what makes isNonMonotonic() a real, testable signal rather than one
-                // that binary chop's own strictly-nested bracket could never actually trigger.
+                // Require requiredConfirmationHolds more consecutive clean holds at the same
+                // rate before accepting it -- this is what makes isNonMonotonic() a real,
+                // testable signal rather than one that binary chop's own strictly-nested
+                // bracket could never actually trigger.
                 confirming = true;
+                confirmationHoldsPassed = 0;
                 currentRate = lo;
                 return false;
             }
+            confirmationHoldsPassed++;
+            if (confirmationHoldsPassed >= requiredConfirmationHolds) {
+                currentRate = lo;
+                confirmed = true;
+                phase = Phase.DONE;
+                return true;
+            }
             currentRate = lo;
-            confirmed = true;
-            phase = Phase.DONE;
-            return true;
+            return false;
         }
 
         confirming = false;
@@ -202,6 +236,19 @@ class RampRateFinder {
             currentRate = lo;
         }
         phase = Phase.DONE;
+    }
+
+    // The highest rate ever recorded as a pass strictly below `ceiling` -- used to reopen the
+    // search on a safe, already-observed footing after a failed confirmation, rather than a
+    // blind guess. Falls back to a fixed backoff only if history somehow has no such rate yet.
+    private double bestKnownPassBelow(double ceiling) {
+        double best = 0;
+        for (RateVerdict v : history) {
+            if (v.passed && v.rate < ceiling && v.rate > best) {
+                best = v.rate;
+            }
+        }
+        return best > 0 ? best : ceiling * CONFIRMATION_BACKOFF_FACTOR;
     }
 
     private void recordVerdict(double rate, boolean passed) {

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/RampRateFinder.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/RampRateFinder.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openmessaging.benchmark;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static lombok.AccessLevel.PACKAGE;
+
+import io.openmessaging.benchmark.utils.Env;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+
+/**
+ * Discovers the maximum sustainable producer rate: an exponential bracket phase finds a
+ * known-good/known-bad pair around the knee, then a binary-chop phase holds and verifies each
+ * candidate rate for a fixed window before accepting it, converging to a rate within a
+ * configured tolerance.
+ *
+ * <p>Deliberately takes elapsed time and cumulative counters as explicit parameters (rather than
+ * reading the clock itself) so it remains a fast, deterministic pure state machine to unit test;
+ * the caller owns real sleeping/timing.
+ */
+class RampRateFinder {
+    private static final long ONE_SECOND_IN_NANOS = SECONDS.toNanos(1);
+    private static final int MAX_BRACKET_ITERATIONS = 20;
+
+    enum Phase {
+        BRACKET,
+        CHOP,
+        DONE
+    }
+
+    private final long publishBacklogLimit;
+    private final long receiveBacklogLimit;
+    private final long holdNanos;
+    private final double convergenceTolerance;
+    private final long maxDiscoveryNanos;
+
+    @Getter(PACKAGE)
+    private Phase phase = Phase.BRACKET;
+
+    @Getter(PACKAGE)
+    private Double lo;
+
+    @Getter(PACKAGE)
+    private Double hi;
+
+    @Getter private double currentRate;
+
+    @Getter private boolean nonMonotonic = false;
+
+    private boolean confirming = false;
+    private long previousTotalPublished = 0;
+    private long elapsedHoldNanos = 0;
+    private long totalElapsedNanos = 0;
+    private int bracketIterations = 0;
+
+    private final List<RateVerdict> history = new ArrayList<>();
+
+    RampRateFinder(Workload workload) {
+        this.currentRate =
+                workload.rampStartRate != null ? workload.rampStartRate.doubleValue() : 10000.0;
+        this.publishBacklogLimit =
+                workload.rampPublishBacklogLimit != null
+                        ? workload.rampPublishBacklogLimit.longValue()
+                        : Env.getLong("PUBLISH_BACKLOG_LIMIT", 1_000);
+        this.receiveBacklogLimit =
+                workload.rampReceiveBacklogLimit != null
+                        ? workload.rampReceiveBacklogLimit.longValue()
+                        : Env.getLong("RECEIVE_BACKLOG_LIMIT", 1_000);
+        int holdSeconds =
+                workload.rampHoldSeconds != null ? workload.rampHoldSeconds.intValue() : 30;
+        this.holdNanos = SECONDS.toNanos(holdSeconds);
+        this.convergenceTolerance =
+                workload.rampConvergenceTolerance != null
+                        ? workload.rampConvergenceTolerance.doubleValue()
+                        : 0.05;
+        int maxDiscoveryMinutes =
+                workload.rampMaxDiscoveryMinutes != null
+                        ? workload.rampMaxDiscoveryMinutes.intValue()
+                        : 10;
+        this.maxDiscoveryNanos = MINUTES.toNanos(maxDiscoveryMinutes);
+    }
+
+    // Advances the state machine given the latest period's counters. Returns true when done.
+    boolean poll(long periodNanos, long totalPublished, long totalReceived) {
+        if (phase == Phase.DONE) {
+            return true;
+        }
+
+        totalElapsedNanos += periodNanos;
+        if (totalElapsedNanos >= maxDiscoveryNanos) {
+            finishWithBestKnown();
+            return true;
+        }
+
+        long expected = (long) ((currentRate / ONE_SECOND_IN_NANOS) * periodNanos);
+        long published = totalPublished - previousTotalPublished;
+        long receiveBacklog = totalPublished - totalReceived;
+        long publishBacklog = expected - published;
+        previousTotalPublished = totalPublished;
+
+        boolean backlogExceeded =
+                receiveBacklog > receiveBacklogLimit || publishBacklog > publishBacklogLimit;
+
+        return phase == Phase.BRACKET
+                ? pollBracket(backlogExceeded)
+                : pollChop(backlogExceeded, periodNanos);
+    }
+
+    private boolean pollBracket(boolean backlogExceeded) {
+        recordVerdict(currentRate, !backlogExceeded);
+
+        if (backlogExceeded) {
+            hi = currentRate;
+        } else {
+            lo = currentRate;
+        }
+
+        if (lo != null && hi != null) {
+            phase = Phase.CHOP;
+            elapsedHoldNanos = 0;
+            currentRate = (lo + hi) / 2.0;
+            return false;
+        }
+
+        bracketIterations++;
+        if (bracketIterations >= MAX_BRACKET_ITERATIONS) {
+            finishWithBestKnown();
+            return true;
+        }
+
+        currentRate = backlogExceeded ? currentRate / 2.0 : currentRate * 2.0;
+        return false;
+    }
+
+    private boolean pollChop(boolean backlogExceeded, long periodNanos) {
+        if (backlogExceeded) {
+            recordVerdict(currentRate, false);
+            if (confirming) {
+                // The converged rate didn't hold on re-check. Stop anyway (best effort) --
+                // isNonMonotonic() is now true so the caller can warn about reproducibility.
+                phase = Phase.DONE;
+                return true;
+            }
+            hi = currentRate;
+            elapsedHoldNanos = 0;
+            currentRate = (lo + hi) / 2.0;
+            return false;
+        }
+
+        elapsedHoldNanos += periodNanos;
+        if (elapsedHoldNanos < holdNanos) {
+            return false;
+        }
+
+        recordVerdict(currentRate, true);
+        elapsedHoldNanos = 0;
+
+        if (!confirming) {
+            lo = currentRate;
+        }
+
+        if ((hi - lo) / lo <= convergenceTolerance) {
+            if (!confirming) {
+                // Require one more confirmation hold at the same rate before accepting it --
+                // this is what makes isNonMonotonic() a real, testable signal rather than one
+                // that binary chop's own strictly-nested bracket could never actually trigger.
+                confirming = true;
+                currentRate = lo;
+                return false;
+            }
+            currentRate = lo;
+            phase = Phase.DONE;
+            return true;
+        }
+
+        confirming = false;
+        currentRate = (lo + hi) / 2.0;
+        return false;
+    }
+
+    private void finishWithBestKnown() {
+        if (lo != null) {
+            currentRate = lo;
+        }
+        phase = Phase.DONE;
+    }
+
+    private void recordVerdict(double rate, boolean passed) {
+        for (RateVerdict v : history) {
+            if (passed && !v.passed && rate >= v.rate) {
+                nonMonotonic = true;
+            }
+            if (!passed && v.passed && rate <= v.rate) {
+                nonMonotonic = true;
+            }
+        }
+        history.add(new RateVerdict(rate, passed));
+    }
+
+    private static final class RateVerdict {
+        final double rate;
+        final boolean passed;
+
+        RateVerdict(double rate, boolean passed) {
+            this.rate = rate;
+            this.passed = passed;
+        }
+    }
+}

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/RampRateFinder.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/RampRateFinder.java
@@ -25,8 +25,8 @@ import lombok.Getter;
 /**
  * Discovers the maximum sustainable producer rate: an exponential bracket phase finds a
  * known-good/known-bad pair around the knee, then a binary-chop phase holds and verifies each
- * candidate rate for a fixed window before accepting it, converging to a rate within a
- * configured tolerance.
+ * candidate rate for a fixed window before accepting it, converging to a rate within a configured
+ * tolerance.
  *
  * <p>Deliberately takes elapsed time and cumulative counters as explicit parameters (rather than
  * reading the clock itself) so it remains a fast, deterministic pure state machine to unit test;
@@ -80,17 +80,14 @@ class RampRateFinder {
                 workload.rampReceiveBacklogLimit != null
                         ? workload.rampReceiveBacklogLimit.longValue()
                         : Env.getLong("RECEIVE_BACKLOG_LIMIT", 1_000);
-        int holdSeconds =
-                workload.rampHoldSeconds != null ? workload.rampHoldSeconds.intValue() : 30;
+        int holdSeconds = workload.rampHoldSeconds != null ? workload.rampHoldSeconds.intValue() : 30;
         this.holdNanos = SECONDS.toNanos(holdSeconds);
         this.convergenceTolerance =
                 workload.rampConvergenceTolerance != null
                         ? workload.rampConvergenceTolerance.doubleValue()
                         : 0.05;
         int maxDiscoveryMinutes =
-                workload.rampMaxDiscoveryMinutes != null
-                        ? workload.rampMaxDiscoveryMinutes.intValue()
-                        : 10;
+                workload.rampMaxDiscoveryMinutes != null ? workload.rampMaxDiscoveryMinutes.intValue() : 10;
         this.maxDiscoveryNanos = MINUTES.toNanos(maxDiscoveryMinutes);
     }
 

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/RampRateFinder.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/RampRateFinder.java
@@ -23,10 +23,10 @@ import java.util.List;
 import lombok.Getter;
 
 /**
- * Discovers the maximum sustainable producer rate: an exponential bracket phase finds a
- * known-good/known-bad pair around the knee, then a binary-chop phase holds and verifies each
- * candidate rate for a fixed window before accepting it, converging to a rate within a configured
- * tolerance.
+ * Discovers the maximum sustainable producer rate: after an initial settle period, an exponential
+ * bracket phase finds a known-good/known-bad pair around the knee, then a binary-chop phase narrows
+ * within it -- both phases hold every candidate for a configured duration before trusting it clean,
+ * converging to a rate within a configured tolerance.
  *
  * <p>Deliberately takes elapsed time and cumulative counters as explicit parameters (rather than
  * reading the clock itself) so it remains a fast, deterministic pure state machine to unit test;
@@ -50,6 +50,8 @@ class RampRateFinder {
     private final long publishBacklogLimit;
     private final long receiveBacklogLimit;
     private final Double maxBacklogSeconds;
+    private final long settleNanos;
+    private final long bracketHoldNanos;
     private final long holdNanos;
     private final double convergenceTolerance;
     private final long maxDiscoveryNanos;
@@ -76,7 +78,11 @@ class RampRateFinder {
     @Getter(PACKAGE)
     private boolean confirmed = false;
 
+    @Getter(PACKAGE)
+    private boolean settled = false;
+
     private long previousTotalPublished = 0;
+    private long elapsedSettleNanos = 0;
     private long elapsedHoldNanos = 0;
     private long totalElapsedNanos = 0;
     private int bracketIterations = 0;
@@ -96,8 +102,16 @@ class RampRateFinder {
                         ? workload.rampReceiveBacklogLimit.longValue()
                         : Env.getLong("RECEIVE_BACKLOG_LIMIT", 1_000);
         this.maxBacklogSeconds = workload.rampMaxBacklogSeconds;
+        int settleSeconds =
+                workload.rampSettleSeconds != null ? workload.rampSettleSeconds.intValue() : 30;
+        this.settleNanos = SECONDS.toNanos(settleSeconds);
         int holdSeconds = workload.rampHoldSeconds != null ? workload.rampHoldSeconds.intValue() : 30;
         this.holdNanos = SECONDS.toNanos(holdSeconds);
+        int bracketHoldSeconds =
+                workload.rampBracketHoldSeconds != null
+                        ? workload.rampBracketHoldSeconds.intValue()
+                        : holdSeconds;
+        this.bracketHoldNanos = SECONDS.toNanos(bracketHoldSeconds);
         this.convergenceTolerance =
                 workload.rampConvergenceTolerance != null
                         ? workload.rampConvergenceTolerance.doubleValue()
@@ -121,6 +135,19 @@ class RampRateFinder {
             return true;
         }
 
+        if (!settled) {
+            elapsedSettleNanos += periodNanos;
+            // Keep the published baseline current while ignoring backlog entirely, so whatever
+            // happened during settling (consumer-group rebalance tail, producer connection
+            // warm-up) can never be mistaken for the candidate rate being unsustainable.
+            previousTotalPublished = totalPublished;
+            if (elapsedSettleNanos < settleNanos) {
+                return false;
+            }
+            settled = true;
+            return false;
+        }
+
         long expected = (long) ((currentRate / ONE_SECOND_IN_NANOS) * periodNanos);
         long published = totalPublished - previousTotalPublished;
         long receiveBacklog = totalPublished - totalReceived;
@@ -140,22 +167,29 @@ class RampRateFinder {
         }
 
         return phase == Phase.BRACKET
-                ? pollBracket(backlogExceeded)
+                ? pollBracket(backlogExceeded, periodNanos)
                 : pollChop(backlogExceeded, periodNanos);
     }
 
-    private boolean pollBracket(boolean backlogExceeded) {
-        recordVerdict(currentRate, !backlogExceeded);
-
+    private boolean pollBracket(boolean backlogExceeded, long periodNanos) {
         if (backlogExceeded) {
+            // A breach is immediately actionable -- no need to hold out a failing candidate,
+            // same fail-fast principle the chop phase already uses.
+            recordVerdict(currentRate, false);
             hi = currentRate;
+            elapsedHoldNanos = 0;
         } else {
+            elapsedHoldNanos += periodNanos;
+            if (elapsedHoldNanos < bracketHoldNanos) {
+                return false;
+            }
+            recordVerdict(currentRate, true);
+            elapsedHoldNanos = 0;
             lo = currentRate;
         }
 
         if (lo != null && hi != null) {
             phase = Phase.CHOP;
-            elapsedHoldNanos = 0;
             currentRate = (lo + hi) / 2.0;
             return false;
         }

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/RampRateFinder.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/RampRateFinder.java
@@ -61,7 +61,14 @@ class RampRateFinder {
 
     @Getter private boolean nonMonotonic = false;
 
+    @Getter(PACKAGE)
     private boolean confirming = false;
+
+    // True only when discovery ended via a genuine two-hold confirm -- never set by the safety
+    // cap or by a rejected confirmation hold, so callers can tell those apart from the outside.
+    @Getter(PACKAGE)
+    private boolean confirmed = false;
+
     private long previousTotalPublished = 0;
     private long elapsedHoldNanos = 0;
     private long totalElapsedNanos = 0;
@@ -180,6 +187,7 @@ class RampRateFinder {
                 return false;
             }
             currentRate = lo;
+            confirmed = true;
             phase = Phase.DONE;
             return true;
         }

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/RampVerification.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/RampVerification.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openmessaging.benchmark;
+
+/**
+ * The window during which a CHOP ramp discovery held and confirmed its final accepted rate.
+ * Attached to {@link TestResult} only when {@code rampAlgorithm == CHOP} and discovery ended in a
+ * genuine confirm, not a safety-cap or rejected-confirmation outcome.
+ */
+public class RampVerification {
+    public double rate;
+    public long startEpochMillis;
+    public long endEpochMillis;
+    public boolean nonMonotonic;
+}

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/RampVerification.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/RampVerification.java
@@ -15,8 +15,12 @@ package io.openmessaging.benchmark;
 
 /**
  * The window during which a CHOP ramp discovery held and confirmed its final accepted rate.
- * Attached to {@link TestResult} only when {@code rampAlgorithm == CHOP} and discovery ended in a
- * genuine confirm, not a safety-cap or rejected-confirmation outcome.
+ * Attached to {@link TestResult} only when {@code rampAlgorithm == CHOP}, discovery ended in a
+ * genuine confirm (not a safety-cap or rejected-confirmation outcome), and nothing during discovery
+ * ever contradicted anything else -- so {@code nonMonotonic} is always {@code false} whenever this
+ * object is actually present; a contradicted discovery is withheld entirely rather than reported as
+ * a specific, possibly-unreproducible rate. The field is kept (rather than removed) for JSON schema
+ * stability.
  */
 public class RampVerification {
     public double rate;

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/RateController.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/RateController.java
@@ -35,8 +35,18 @@ class RateController {
     private long previousTotalReceived = 0;
 
     RateController() {
-        publishBacklogLimit = Env.getLong("PUBLISH_BACKLOG_LIMIT", 1_000);
-        receiveBacklogLimit = Env.getLong("RECEIVE_BACKLOG_LIMIT", 1_000);
+        this(null, null);
+    }
+
+    RateController(Long publishBacklogLimit, Long receiveBacklogLimit) {
+        this.publishBacklogLimit =
+                publishBacklogLimit != null
+                        ? publishBacklogLimit
+                        : Env.getLong("PUBLISH_BACKLOG_LIMIT", 1_000);
+        this.receiveBacklogLimit =
+                receiveBacklogLimit != null
+                        ? receiveBacklogLimit
+                        : Env.getLong("RECEIVE_BACKLOG_LIMIT", 1_000);
         minRampingFactor = Env.getDouble("MIN_RAMPING_FACTOR", 0.01);
         maxRampingFactor = Env.getDouble("MAX_RAMPING_FACTOR", 1);
         rampingFactor = maxRampingFactor;

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/TestResult.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/TestResult.java
@@ -14,6 +14,7 @@
 package io.openmessaging.benchmark;
 
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -27,6 +28,10 @@ public class TestResult {
     public int partitions;
     public int producersPerTopic;
     public int consumersPerTopic;
+
+    // Only present for rampAlgorithm: CHOP workloads that reached a genuine confirm.
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public RampVerification rampVerification;
 
     public List<Double> publishRate = new ArrayList<>();
     public List<Double> publishErrorRate = new ArrayList<>();

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
@@ -89,6 +89,16 @@ public class Workload {
     public Double rampMaxBacklogSeconds;
 
     /**
+     * CHOP only: hard floor (in messages) on the limit rampMaxBacklogSeconds computes. Without it, a
+     * single early false failure halves the candidate rate and, in the same stroke, halves the
+     * tolerance too -- the wrong direction for a recovery mechanism -- letting one bad reading
+     * cascade all the way down to a near-zero "confirmed" rate. Defaults to 1000, matching the old
+     * fixed-count default so the relative check can never become stricter than a fixed-count check
+     * would have been. Only meaningful when rampMaxBacklogSeconds is set.
+     */
+    public Long rampMaxBacklogFloor;
+
+    /**
      * CHOP only: hard cap (in messages) on the limit rampMaxBacklogSeconds computes, so the tolerance
      * can't grow unbounded as bracket's exponential doubling searches far past the real ceiling --
      * without it, a high enough candidate rate can make the relative check tolerate an enormous

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
@@ -80,11 +80,26 @@ public class Workload {
      */
     public Long rampReceiveBacklogLimit;
 
+    /**
+     * CHOP only: backlog limit expressed as seconds' worth of the candidate rate (limit = currentRate
+     * * rampMaxBacklogSeconds) instead of a fixed message count, so the check is equally strict at
+     * every rate tested during the bracket phase's exponential range. When set, this replaces
+     * rampPublishBacklogLimit/rampReceiveBacklogLimit for CHOP. Unset by default.
+     */
+    public Double rampMaxBacklogSeconds;
+
     /** CHOP only: seconds between bracket-phase steps / hold-phase polls. Defaults to 3. */
     public Integer rampBracketPeriodSeconds;
 
     /** CHOP only: seconds to hold and verify each candidate rate. Defaults to 30. */
     public Integer rampHoldSeconds;
+
+    /**
+     * CHOP only: number of consecutive clean confirmation holds required at the same rate before
+     * accepting it, beyond the initial tolerance-meeting hold. Defaults to 1. Raising this trades
+     * discovery time for confidence that the accepted rate isn't a one-off pass.
+     */
+    public Integer rampConfirmationHolds;
 
     /** CHOP only: relative (hi - lo) / lo band at which to stop chopping. Defaults to 0.05. */
     public Double rampConvergenceTolerance;

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
@@ -91,7 +91,22 @@ public class Workload {
     /** CHOP only: seconds between bracket-phase steps / hold-phase polls. Defaults to 3. */
     public Integer rampBracketPeriodSeconds;
 
-    /** CHOP only: seconds to hold and verify each candidate rate. Defaults to 30. */
+    /**
+     * CHOP only: seconds to run at rampStartRate before backlog is evaluated at all, so a
+     * consumer-group rebalance tail or producer connection warm-up still settling right after the
+     * load starts can never be mistaken for the candidate rate being unsustainable. Defaults to 30.
+     */
+    public Integer rampSettleSeconds;
+
+    /**
+     * CHOP only: seconds a bracket-phase candidate (the exponential doubling/halving search that
+     * finds the initial [lo, hi] window) must hold clean before being accepted. Defaults to the
+     * resolved rampHoldSeconds, i.e. bracket and chop are equally rigorous unless you explicitly
+     * shorten this once you trust bracket's coarser candidates need less scrutiny.
+     */
+    public Integer rampBracketHoldSeconds;
+
+    /** CHOP only: seconds to hold and verify each chop-phase candidate. Defaults to 30. */
     public Integer rampHoldSeconds;
 
     /**

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
@@ -61,19 +61,23 @@ public class Workload {
     public int producerRate;
 
     /**
-     * The following fields only apply when producerRate == 0, i.e. when the generator probes for
-     * the maximum sustainable rate (a "ramp test"). Leave unset to fall back to the existing
-     * env-var / hardcoded defaults.
+     * The following fields only apply when producerRate == 0, i.e. when the generator probes for the
+     * maximum sustainable rate (a "ramp test"). Leave unset to fall back to the existing env-var /
+     * hardcoded defaults.
      */
     public RampAlgorithm rampAlgorithm = RampAlgorithm.AIMD;
 
     /** Initial probe rate for ramp discovery. Defaults to 10000 if unset. */
     public Integer rampStartRate;
 
-    /** Publish backlog limit used by ramp discovery. Defaults to env PUBLISH_BACKLOG_LIMIT, else 1000. */
+    /**
+     * Publish backlog limit used by ramp discovery. Defaults to env PUBLISH_BACKLOG_LIMIT, else 1000.
+     */
     public Long rampPublishBacklogLimit;
 
-    /** Receive backlog limit used by ramp discovery. Defaults to env RECEIVE_BACKLOG_LIMIT, else 1000. */
+    /**
+     * Receive backlog limit used by ramp discovery. Defaults to env RECEIVE_BACKLOG_LIMIT, else 1000.
+     */
     public Long rampReceiveBacklogLimit;
 
     /** CHOP only: seconds between bracket-phase steps / hold-phase polls. Defaults to 3. */

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
@@ -61,6 +61,34 @@ public class Workload {
     public int producerRate;
 
     /**
+     * The following fields only apply when producerRate == 0, i.e. when the generator probes for
+     * the maximum sustainable rate (a "ramp test"). Leave unset to fall back to the existing
+     * env-var / hardcoded defaults.
+     */
+    public RampAlgorithm rampAlgorithm = RampAlgorithm.AIMD;
+
+    /** Initial probe rate for ramp discovery. Defaults to 10000 if unset. */
+    public Integer rampStartRate;
+
+    /** Publish backlog limit used by ramp discovery. Defaults to env PUBLISH_BACKLOG_LIMIT, else 1000. */
+    public Long rampPublishBacklogLimit;
+
+    /** Receive backlog limit used by ramp discovery. Defaults to env RECEIVE_BACKLOG_LIMIT, else 1000. */
+    public Long rampReceiveBacklogLimit;
+
+    /** CHOP only: seconds between bracket-phase steps / hold-phase polls. Defaults to 3. */
+    public Integer rampBracketPeriodSeconds;
+
+    /** CHOP only: seconds to hold and verify each candidate rate. Defaults to 30. */
+    public Integer rampHoldSeconds;
+
+    /** CHOP only: relative (hi - lo) / lo band at which to stop chopping. Defaults to 0.05. */
+    public Double rampConvergenceTolerance;
+
+    /** CHOP only: safety cap on total discovery time, in minutes. Defaults to 10. */
+    public Integer rampMaxDiscoveryMinutes;
+
+    /**
      * If the consumer backlog is > 0, the generator will accumulate messages until the requested
      * amount of storage is retained and then it will start the consumers to drain it.
      *

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
@@ -88,6 +88,15 @@ public class Workload {
      */
     public Double rampMaxBacklogSeconds;
 
+    /**
+     * CHOP only: hard cap (in messages) on the limit rampMaxBacklogSeconds computes, so the tolerance
+     * can't grow unbounded as bracket's exponential doubling searches far past the real ceiling --
+     * without it, a high enough candidate rate can make the relative check tolerate an enormous
+     * backlog and report a wildly implausible "confirmed" rate. Only meaningful when
+     * rampMaxBacklogSeconds is set. Defaults to 100000.
+     */
+    public Long rampMaxBacklogCeiling;
+
     /** CHOP only: seconds between bracket-phase steps / hold-phase polls. Defaults to 3. */
     public Integer rampBracketPeriodSeconds;
 

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
@@ -32,6 +32,7 @@ import io.openmessaging.benchmark.worker.commands.TopicSubscription;
 import io.openmessaging.benchmark.worker.commands.TopicsInfo;
 import java.io.IOException;
 import java.text.DecimalFormat;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -56,6 +57,8 @@ public class WorkloadGenerator implements AutoCloseable {
     private volatile boolean needToWaitForBacklogDraining = false;
 
     private volatile double targetPublishRate;
+
+    private RampVerification rampVerification;
 
     public WorkloadGenerator(String driverName, Workload workload, Worker worker) {
         this.driverName = driverName;
@@ -271,6 +274,8 @@ public class WorkloadGenerator implements AutoCloseable {
 
         long lastControlTimestamp = System.nanoTime();
         boolean done = false;
+        boolean wasConfirming = finder.isConfirming();
+        Instant verificationStartedAt = null;
 
         while (!done && !runCompleted) {
             try {
@@ -286,6 +291,25 @@ public class WorkloadGenerator implements AutoCloseable {
 
             done = finder.poll(periodNanos, stats.messagesSent, stats.messagesReceived);
             worker.adjustPublishRate(finder.getCurrentRate());
+
+            if (!wasConfirming && finder.isConfirming()) {
+                verificationStartedAt = Instant.now();
+            }
+            wasConfirming = finder.isConfirming();
+        }
+
+        if (finder.isConfirmed()) {
+            Instant verificationConfirmedAt = Instant.now();
+            rampVerification = new RampVerification();
+            rampVerification.rate = finder.getCurrentRate();
+            rampVerification.startEpochMillis = verificationStartedAt.toEpochMilli();
+            rampVerification.endEpochMillis = verificationConfirmedAt.toEpochMilli();
+            rampVerification.nonMonotonic = finder.isNonMonotonic();
+            log.info(
+                    "----- CHOP verification window: {} -> {} (rate {} msg/s) -----",
+                    verificationStartedAt,
+                    verificationConfirmedAt,
+                    finder.getCurrentRate());
         }
 
         if (finder.isNonMonotonic()) {
@@ -433,6 +457,7 @@ public class WorkloadGenerator implements AutoCloseable {
                         : workload.messageSize;
         result.producersPerTopic = workload.producersPerTopic;
         result.consumersPerTopic = workload.consumerPerSubscription;
+        result.rampVerification = rampVerification;
 
         while (true) {
             try {

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
@@ -298,13 +298,13 @@ public class WorkloadGenerator implements AutoCloseable {
             wasConfirming = finder.isConfirming();
         }
 
-        if (finder.isConfirmed()) {
+        if (finder.isConfirmed() && !finder.isNonMonotonic()) {
             Instant verificationConfirmedAt = Instant.now();
             rampVerification = new RampVerification();
             rampVerification.rate = finder.getCurrentRate();
             rampVerification.startEpochMillis = verificationStartedAt.toEpochMilli();
             rampVerification.endEpochMillis = verificationConfirmedAt.toEpochMilli();
-            rampVerification.nonMonotonic = finder.isNonMonotonic();
+            rampVerification.nonMonotonic = false;
             log.info(
                     "----- CHOP verification window: {} -> {} (rate {} msg/s) -----",
                     verificationStartedAt,
@@ -313,10 +313,13 @@ public class WorkloadGenerator implements AutoCloseable {
         }
 
         if (finder.isNonMonotonic()) {
+            // A discovery that contradicted itself anywhere isn't verified, however it ended --
+            // rampVerification is deliberately withheld above rather than reporting a specific
+            // rate that might not reproduce.
             log.warn(
                     "Ramp discovery detected non-monotonic backlog behavior -- {} msg/s may not"
-                            + " reproduce reliably; consider treating it as a band rather than an exact"
-                            + " figure.",
+                            + " reproduce reliably; rampVerification will not be attached to the"
+                            + " result. Treat this as a band rather than an exact figure.",
                     finder.getCurrentRate());
         }
         log.info("----- Ramp discovery (CHOP) complete: {} msg/s -----", finder.getCurrentRate());

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
@@ -83,17 +83,20 @@ public class WorkloadGenerator implements AutoCloseable {
             targetPublishRate = workload.producerRate;
         } else {
             // Producer rate is 0 and we need to discover the sustainable rate
-            targetPublishRate = 10000;
+            targetPublishRate =
+                    workload.rampStartRate != null ? workload.rampStartRate.doubleValue() : 10000.0;
 
-            executor.execute(
-                    () -> {
-                        // Run background controller to adjust rate
-                        try {
-                            findMaximumSustainableRate(targetPublishRate);
-                        } catch (IOException e) {
-                            log.warn("Failure in finding max sustainable rate", e);
-                        }
-                    });
+            if (workload.rampAlgorithm == RampAlgorithm.AIMD) {
+                executor.execute(
+                        () -> {
+                            // Run background controller to adjust rate
+                            try {
+                                findMaximumSustainableRate(targetPublishRate);
+                            } catch (IOException e) {
+                                log.warn("Failure in finding max sustainable rate", e);
+                            }
+                        });
+            }
         }
 
         ProducerWorkAssignment producerWorkAssignment = new ProducerWorkAssignment();
@@ -146,6 +149,10 @@ public class WorkloadGenerator implements AutoCloseable {
         }
 
         worker.startLoad(producerWorkAssignment);
+
+        if (workload.producerRate == 0 && workload.rampAlgorithm == RampAlgorithm.CHOP) {
+            runChopDiscovery();
+        }
 
         if (workload.warmupDurationMinutes > 0) {
             log.info("----- Starting warm-up traffic ({}m) ------", workload.warmupDurationMinutes);
@@ -223,7 +230,8 @@ public class WorkloadGenerator implements AutoCloseable {
         int controlPeriodMillis = 3000;
         long lastControlTimestamp = System.nanoTime();
 
-        RateController rateController = new RateController();
+        RateController rateController =
+                new RateController(workload.rampPublishBacklogLimit, workload.rampReceiveBacklogLimit);
 
         while (!runCompleted) {
             // Check every few seconds and adjust the rate
@@ -245,6 +253,49 @@ public class WorkloadGenerator implements AutoCloseable {
                             currentRate, periodNanos, stats.messagesSent, stats.messagesReceived);
             worker.adjustPublishRate(currentRate);
         }
+    }
+
+    /**
+     * Discovers the maximum sustainable rate via bracket + binary-chop + hold-and-verify
+     * (RampAlgorithm.CHOP), blocking until the search converges or hits its safety cap, so that
+     * warmup/measurement start at an already-verified, fixed rate instead of a rate still being
+     * adjusted.
+     */
+    private void runChopDiscovery() throws IOException {
+        int bracketPeriodSeconds =
+                workload.rampBracketPeriodSeconds != null ? workload.rampBracketPeriodSeconds : 3;
+        long pollMillis = TimeUnit.SECONDS.toMillis(bracketPeriodSeconds);
+
+        RampRateFinder finder = new RampRateFinder(workload);
+        worker.adjustPublishRate(finder.getCurrentRate());
+
+        long lastControlTimestamp = System.nanoTime();
+        boolean done = false;
+
+        while (!done && !runCompleted) {
+            try {
+                Thread.sleep(pollMillis);
+            } catch (InterruptedException e) {
+                return;
+            }
+
+            CountersStats stats = worker.getCountersStats();
+            long currentTime = System.nanoTime();
+            long periodNanos = currentTime - lastControlTimestamp;
+            lastControlTimestamp = currentTime;
+
+            done = finder.poll(periodNanos, stats.messagesSent, stats.messagesReceived);
+            worker.adjustPublishRate(finder.getCurrentRate());
+        }
+
+        if (finder.isNonMonotonic()) {
+            log.warn(
+                    "Ramp discovery detected non-monotonic backlog behavior -- {} msg/s may not"
+                            + " reproduce reliably; consider treating it as a band rather than an exact"
+                            + " figure.",
+                    finder.getCurrentRate());
+        }
+        log.info("----- Ramp discovery (CHOP) complete: {} msg/s -----", finder.getCurrentRate());
     }
 
     @Override

--- a/benchmark-framework/src/test/java/io/openmessaging/benchmark/ChopRateFinderKafkaIT.java
+++ b/benchmark-framework/src/test/java/io/openmessaging/benchmark/ChopRateFinderKafkaIT.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openmessaging.benchmark;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openmessaging.benchmark.worker.LocalWorker;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * End-to-end integration test for the opt-in CHOP rate finder, driving the real {@link
+ * WorkloadGenerator} discovery loop against a throwaway Kafka broker.
+ *
+ * <p>This is the first automated test in the repo that exercises a rate finder against an actual
+ * broker rather than hand-fed counters. {@code RampRateFinderTest} proves the clamp
+ * <em>arithmetic</em> deterministically (via a {@code FakeSystem}); this proves the clamps survive
+ * the <em>integrated</em> path -- real producers/consumers, real backlog signals, real hold timing
+ * -- which is exactly the layer where both AKS "Trial finding" incidents in {@code RATE_FINDING.md}
+ * lived.
+ *
+ * <p>Skipped by default (failsafe {@code skipITs=true}) so PR CI stays fast and Docker-free. Run it
+ * on demand with a Docker daemon available: {@code mvn -pl benchmark-framework verify
+ * -Pintegration-tests}. Takes a few minutes -- discovery holds must be long enough that a bursting
+ * broker cannot masquerade an unsustainable rate as clean.
+ */
+@Testcontainers
+class ChopRateFinderKafkaIT {
+
+    private static final Logger log = LoggerFactory.getLogger(ChopRateFinderKafkaIT.class);
+
+    @Container
+    static final KafkaContainer KAFKA =
+            new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.6.1"));
+
+    /**
+     * The claim CHOP makes that AIMD never did: the rate it confirms is one you can actually hold.
+     * This drives real discovery against a real broker with a realistic starting rate, then checks
+     * the measurement window that ran at the confirmed rate -- if that rate is genuinely sustainable,
+     * publish-delay (the rate limiter's backlog of un-sent messages) stays bounded rather than
+     * growing without limit. This is the end-to-end analogue of the manual AKS check that first
+     * exposed CHOP over-confirming (converged 8062 msg/s, then 35k messages of backlog in the very
+     * next window).
+     */
+    @Test
+    void chopConfirmedRateIsActuallySustainableAgainstARealBroker() throws Exception {
+        File driverConfig = writeKafkaDriverConfig(KAFKA.getBootstrapServers());
+
+        Workload workload = discoveryWorkload();
+        LocalWorker worker = new LocalWorker();
+        worker.initializeDriver(driverConfig);
+
+        TestResult result;
+        try (WorkloadGenerator generator = new WorkloadGenerator("Kafka", workload, worker)) {
+            result = generator.run();
+        }
+
+        Double confirmedRate = result.rampVerification == null ? null : result.rampVerification.rate;
+        double pubDelayAvgMs = result.aggregatedPublishDelayLatencyAvg / 1000.0;
+        long maxBacklog = result.backlog.stream().mapToLong(Long::longValue).max().orElse(0L);
+        log.info(
+                "CHOP confirmedRate={} msg/s | measurement window: avgPublishDelay={} ms,"
+                        + " maxBacklog={} msgs",
+                confirmedRate,
+                String.format("%.1f", pubDelayAvgMs),
+                maxBacklog);
+
+        // Sustainability: at a rate that was truly verified, the producer keeps up, so the average
+        // send delay over the measurement window stays small. A rate that only survived discovery
+        // by bursting shows delay climbing into the seconds -- the signature of an over-confirm.
+        assertThat(pubDelayAvgMs)
+                .as(
+                        "confirmed rate %s msg/s should be sustainable, but the measurement window's"
+                                + " average publish delay indicates the producer could not keep up",
+                        confirmedRate)
+                .isLessThan(500.0);
+    }
+
+    private static Workload discoveryWorkload() {
+        Workload workload = new Workload();
+        workload.name = "chop-sustainability-it";
+        workload.topics = 1;
+        workload.partitionsPerTopic = 10;
+        workload.messageSize = 100;
+        // Build the payload in-memory so no payload/*.data file is needed.
+        workload.useRandomizedPayloads = true;
+        workload.randomBytesRatio = 1.0;
+        workload.randomizedPayloadPoolSize = 1;
+        workload.subscriptionsPerTopic = 1;
+        workload.producersPerTopic = 1;
+        workload.consumerPerSubscription = 1;
+
+        workload.producerRate = 0; // discover the rate
+        workload.rampAlgorithm = RampAlgorithm.CHOP;
+        workload.rampStartRate = 5000; // a realistic starting point, not an adversarial one
+        workload.rampMaxBacklogSeconds = 0.1;
+
+        // Short timings so the IT finishes quickly; the clamp behaviour is per-poll, not
+        // hold-length dependent, so shrinking these doesn't weaken what's under test.
+        workload.rampBracketPeriodSeconds = 2;
+        workload.rampSettleSeconds = 5;
+        workload.rampBracketHoldSeconds = 15;
+        workload.rampHoldSeconds = 20; // long enough that a burst cannot masquerade as sustainable
+        workload.rampConvergenceTolerance = 0.05;
+        workload.rampMaxDiscoveryMinutes = 6; // safety cap
+
+        workload.consumerBacklogSizeGB = 0;
+        workload.warmupDurationMinutes = 0;
+        workload.testDurationMinutes = 1; // measurement window whose delay reveals (un)sustainability
+        return workload;
+    }
+
+    private static File writeKafkaDriverConfig(String bootstrapServers) throws Exception {
+        // Single-broker container: replicationFactor 1 and min.insync.replicas 1 (the shipped
+        // example uses 3/2, which cannot be satisfied here). cp-kafka's Testcontainers image
+        // already forces the __consumer_offsets replication factor to 1 for single-node.
+        String yaml =
+                "name: Kafka\n"
+                        + "driverClass: io.openmessaging.benchmark.driver.kafka.KafkaBenchmarkDriver\n"
+                        + "replicationFactor: 1\n"
+                        + "topicConfig: |\n"
+                        + "  min.insync.replicas=1\n"
+                        + "commonConfig: |\n"
+                        + "  bootstrap.servers="
+                        + bootstrapServers
+                        + "\n"
+                        + "producerConfig: |\n"
+                        + "  acks=all\n"
+                        + "  linger.ms=1\n"
+                        + "consumerConfig: |\n"
+                        + "  auto.offset.reset=earliest\n"
+                        + "  enable.auto.commit=false\n";
+        File file = Files.createTempFile("kafka-driver-it", ".yaml").toFile();
+        file.deleteOnExit();
+        Files.write(file.toPath(), yaml.getBytes(StandardCharsets.UTF_8));
+        return file;
+    }
+}

--- a/benchmark-framework/src/test/java/io/openmessaging/benchmark/RampRateFinderTest.java
+++ b/benchmark-framework/src/test/java/io/openmessaging/benchmark/RampRateFinderTest.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openmessaging.benchmark;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class RampRateFinderTest {
+
+    private static Workload workload() {
+        Workload workload = new Workload();
+        workload.rampPublishBacklogLimit = 100L;
+        workload.rampReceiveBacklogLimit = 100L;
+        return workload;
+    }
+
+    @Test
+    void bracketDoublesUntilBacklogThenTransitionsToChop() {
+        Workload workload = workload();
+        workload.rampStartRate = 1000;
+        RampRateFinder finder = new RampRateFinder(workload);
+        FakeSystem system = new FakeSystem(4500);
+        long periodNanos = SECONDS.toNanos(3);
+
+        assertThat(finder.getPhase()).isEqualTo(RampRateFinder.Phase.BRACKET);
+
+        // 1000 -> clean, 2000 -> clean, 4000 -> clean, 8000 -> exceeds capacity
+        for (int i = 0; i < 4; i++) {
+            system.advance(finder.getCurrentRate(), periodNanos);
+            finder.poll(periodNanos, system.totalPublished, system.totalReceived);
+        }
+
+        assertThat(finder.getPhase()).isEqualTo(RampRateFinder.Phase.CHOP);
+        assertThat(finder.getLo()).isEqualTo(4000.0);
+        assertThat(finder.getHi()).isEqualTo(8000.0);
+        assertThat(finder.getCurrentRate()).isEqualTo(6000.0);
+    }
+
+    @Test
+    void chopConvergesWithinToleranceAndReportsLo() {
+        Workload workload = workload();
+        workload.rampStartRate = 1000;
+        workload.rampHoldSeconds = 6;
+        workload.rampConvergenceTolerance = 0.05;
+        RampRateFinder finder = new RampRateFinder(workload);
+        FakeSystem system = new FakeSystem(4500);
+        long periodNanos = SECONDS.toNanos(3);
+
+        boolean done = false;
+        for (int i = 0; i < 100 && !done; i++) {
+            system.advance(finder.getCurrentRate(), periodNanos);
+            done = finder.poll(periodNanos, system.totalPublished, system.totalReceived);
+        }
+
+        assertThat(done).isTrue();
+        assertThat(finder.getPhase()).isEqualTo(RampRateFinder.Phase.DONE);
+        assertThat(finder.isNonMonotonic()).isFalse();
+        // The backlog limit tolerates a small overshoot past true capacity before it's detected,
+        // so the discovered rate lands just above 4500, not below it -- assert closeness instead.
+        assertThat(Math.abs(4500.0 - finder.getCurrentRate()) / 4500.0).isLessThan(0.05);
+    }
+
+    @Test
+    void holdFailsPartwayExitsEarlyWithoutWaitingOutTheFullHold() {
+        Workload workload = workload();
+        workload.rampStartRate = 1000;
+        workload.rampHoldSeconds = 30; // long hold -- a single failing poll must not wait this out
+        workload.rampConvergenceTolerance = 0.05;
+        RampRateFinder finder = new RampRateFinder(workload);
+        long periodNanos = SECONDS.toNanos(3);
+
+        // Bracket: 1000 clean, 2000 exceeds -> CHOP with lo=1000, hi=2000, mid=1500
+        finder.poll(periodNanos, 3000, 3000);
+        finder.poll(periodNanos, 3000 + 3000, 3000 + 3000);
+        assertThat(finder.getPhase()).isEqualTo(RampRateFinder.Phase.CHOP);
+        assertThat(finder.getCurrentRate()).isEqualTo(1500.0);
+
+        // First hold poll at 1500 is clean (published keeps up with expected)
+        finder.poll(periodNanos, 6000 + 4500, 6000 + 4500);
+        assertThat(finder.getHi()).isEqualTo(2000.0); // unchanged so far
+
+        // Second hold poll at 1500 shows a backlog breach -- must fail immediately, not after 30s
+        boolean done = finder.poll(periodNanos, 10500 + 1000, 10500 + 1000);
+
+        assertThat(done).isFalse();
+        assertThat(finder.getHi()).isEqualTo(1500.0);
+        assertThat(finder.getCurrentRate()).isEqualTo((1000.0 + 1500.0) / 2.0);
+    }
+
+    @Test
+    void nonMonotonicVerdictIsFlaggedWhenConfirmationHoldContradictsThePriorPass() {
+        Workload workload = workload();
+        workload.rampStartRate = 1000;
+        workload.rampHoldSeconds = 3; // one poll completes a hold
+        workload.rampConvergenceTolerance = 0.5; // converge quickly for this test
+        RampRateFinder finder = new RampRateFinder(workload);
+        long periodNanos = SECONDS.toNanos(3);
+
+        // Bracket: 1000 clean, 2000 exceeds -> CHOP, lo=1000, hi=2000, mid=1500
+        finder.poll(periodNanos, 3000, 3000);
+        finder.poll(periodNanos, 6000, 6000);
+        assertThat(finder.getPhase()).isEqualTo(RampRateFinder.Phase.CHOP);
+
+        // Hold at 1500 passes cleanly -- within tolerance (500/1500 = 0.33 <= 0.5), so this
+        // triggers the one-more confirmation hold at the same rate rather than DONE yet.
+        boolean done = finder.poll(periodNanos, 6000 + 4500, 6000 + 4500);
+        assertThat(done).isFalse();
+        assertThat(finder.getCurrentRate()).isEqualTo(1500.0);
+
+        // Confirmation hold at the same rate (1500) now shows a backlog breach -- a direct
+        // contradiction of the pass just recorded at the same rate.
+        done = finder.poll(periodNanos, 10500 + 2000, 10500 + 2000);
+
+        assertThat(done).isTrue();
+        assertThat(finder.getPhase()).isEqualTo(RampRateFinder.Phase.DONE);
+        assertThat(finder.isNonMonotonic()).isTrue();
+    }
+
+    @Test
+    void safetyCapForcesCompletionWithBestKnownRate() {
+        Workload workload = workload();
+        workload.rampStartRate = 1000;
+        workload.rampMaxDiscoveryMinutes = 1;
+        RampRateFinder finder = new RampRateFinder(workload);
+
+        // First poll: clean, establishes lo=1000, well within the 60s cap.
+        boolean done = finder.poll(SECONDS.toNanos(30), 30000, 30000);
+        assertThat(done).isFalse();
+        assertThat(finder.getLo()).isEqualTo(1000.0);
+
+        // Second poll pushes total elapsed time past the 60s cap -- forces completion
+        // regardless of what the counters say.
+        done = finder.poll(SECONDS.toNanos(40), 30000, 30000);
+
+        assertThat(done).isTrue();
+        assertThat(finder.getPhase()).isEqualTo(RampRateFinder.Phase.DONE);
+        assertThat(finder.getCurrentRate()).isEqualTo(1000.0);
+    }
+
+    /** A simple producer-limited system: throughput is capped at {@code capacity} msgs/sec. */
+    private static final class FakeSystem {
+        private final double capacity;
+        long totalPublished = 0;
+        long totalReceived = 0;
+
+        FakeSystem(double capacity) {
+            this.capacity = capacity;
+        }
+
+        void advance(double rate, long periodNanos) {
+            double periodSeconds = periodNanos / 1e9;
+            long sent = (long) (Math.min(rate, capacity) * periodSeconds);
+            totalPublished += sent;
+            totalReceived += sent;
+        }
+    }
+}

--- a/benchmark-framework/src/test/java/io/openmessaging/benchmark/RampRateFinderTest.java
+++ b/benchmark-framework/src/test/java/io/openmessaging/benchmark/RampRateFinderTest.java
@@ -106,7 +106,7 @@ class RampRateFinderTest {
     }
 
     @Test
-    void nonMonotonicVerdictIsFlaggedWhenConfirmationHoldContradictsThePriorPass() {
+    void failedConfirmationReopensTheSearchInsteadOfAcceptingAnUnverifiedRate() {
         Workload workload = workload();
         workload.rampStartRate = 1000;
         workload.rampHoldSeconds = 3; // one poll completes a hold
@@ -130,16 +130,83 @@ class RampRateFinderTest {
         assertThat(finder.isConfirmed()).isFalse();
 
         // Confirmation hold at the same rate (1500) now shows a backlog breach -- a direct
-        // contradiction of the pass just recorded at the same rate.
+        // contradiction of the pass just recorded at the same rate. Rather than accepting this
+        // unverified rate, the search must reopen: tighten hi to 1500 and fall back to the last
+        // rate we've actually seen pass below it (1000, from the bracket phase).
         done = finder.poll(periodNanos, 10500 + 2000, 10500 + 2000);
 
+        assertThat(done).isFalse();
+        assertThat(finder.getPhase()).isEqualTo(RampRateFinder.Phase.CHOP);
+        assertThat(finder.isNonMonotonic()).isTrue();
+        assertThat(finder.isConfirming()).isFalse();
+        assertThat(finder.isConfirmed()).isFalse();
+        assertThat(finder.getLo()).isEqualTo(1000.0);
+        assertThat(finder.getHi()).isEqualTo(1500.0);
+        assertThat(finder.getCurrentRate()).isEqualTo(1250.0);
+
+        // The reopened search can still converge and genuinely confirm on a new, lower candidate.
+        done = finder.poll(periodNanos, 12500 + 3750, 12500 + 3750); // clean hold @1250
+        assertThat(done).isFalse();
+        assertThat(finder.isConfirming()).isTrue();
+
+        done = finder.poll(periodNanos, 16250 + 3750, 16250 + 3750); // clean confirmation hold
         assertThat(done).isTrue();
         assertThat(finder.getPhase()).isEqualTo(RampRateFinder.Phase.DONE);
+        assertThat(finder.isConfirmed()).isTrue();
+        assertThat(finder.getCurrentRate()).isEqualTo(1250.0);
+        // The earlier contradiction is still surfaced even though discovery ultimately confirmed
+        // a (different, lower) rate -- it's evidence the system showed unstable behavior at all.
         assertThat(finder.isNonMonotonic()).isTrue();
-        // Rejected on the confirmation hold, not accepted -- confirmed must stay false even
-        // though confirming (the "we were attempting a confirm" flag) is still true.
+    }
+
+    @Test
+    void multipleConfirmationHoldsAreRequiredWhenConfigured() {
+        Workload workload = workload();
+        workload.rampStartRate = 1000;
+        workload.rampHoldSeconds = 3;
+        workload.rampConvergenceTolerance = 0.5;
+        workload.rampConfirmationHolds = 2;
+        RampRateFinder finder = new RampRateFinder(workload);
+        long periodNanos = SECONDS.toNanos(3);
+
+        finder.poll(periodNanos, 3000, 3000); // bracket: 1000 clean
+        finder.poll(periodNanos, 6000, 6000); // bracket: 2000 exceeds -> CHOP mid=1500
+
+        boolean done = finder.poll(periodNanos, 10500, 10500); // first hold @1500 passes
+        assertThat(done).isFalse();
         assertThat(finder.isConfirming()).isTrue();
+
+        done = finder.poll(periodNanos, 15000, 15000); // 1st confirmation hold passes
+        assertThat(done).isFalse(); // still short of the 2 required confirmation holds
         assertThat(finder.isConfirmed()).isFalse();
+
+        done = finder.poll(periodNanos, 19500, 19500); // 2nd confirmation hold passes
+        assertThat(done).isTrue();
+        assertThat(finder.isConfirmed()).isTrue();
+        assertThat(finder.getCurrentRate()).isEqualTo(1500.0);
+    }
+
+    @Test
+    void relativeBacklogLimitScalesWithCandidateRateUnlikeTheFixedAbsoluteLimit() {
+        long periodNanos = SECONDS.toNanos(1);
+
+        // A 500-message backlog at 100,000 msg/s: negligible in relative terms (5ms worth) but
+        // far above the small fixed absolute default (100 messages) that workload() sets.
+        Workload absolute = workload();
+        absolute.rampStartRate = 100000;
+        RampRateFinder absoluteFinder = new RampRateFinder(absolute);
+        absoluteFinder.poll(periodNanos, 99500, 99500);
+        assertThat(absoluteFinder.getHi()).isEqualTo(100000.0); // absolute limit (100) blown
+        assertThat(absoluteFinder.getLo()).isNull();
+
+        Workload relative = workload();
+        relative.rampStartRate = 100000;
+        relative.rampMaxBacklogSeconds = 0.01; // 1,000 messages allowed at this rate
+        RampRateFinder relativeFinder = new RampRateFinder(relative);
+        relativeFinder.poll(periodNanos, 99500, 99500);
+        // Same backlog, but well under the rate-scaled limit -> treated as clean instead.
+        assertThat(relativeFinder.getLo()).isEqualTo(100000.0);
+        assertThat(relativeFinder.getHi()).isNull();
     }
 
     @Test

--- a/benchmark-framework/src/test/java/io/openmessaging/benchmark/RampRateFinderTest.java
+++ b/benchmark-framework/src/test/java/io/openmessaging/benchmark/RampRateFinderTest.java
@@ -24,18 +24,54 @@ class RampRateFinderTest {
         Workload workload = new Workload();
         workload.rampPublishBacklogLimit = 100L;
         workload.rampReceiveBacklogLimit = 100L;
+        workload.rampSettleSeconds = 0; // most tests don't care about settling; a few override it
         return workload;
+    }
+
+    @Test
+    void settlePeriodIgnoresBacklogEntirelyBeforeRealEvaluationBegins() {
+        Workload workload = workload();
+        workload.rampStartRate = 1000;
+        workload.rampSettleSeconds = 6;
+        workload.rampBracketHoldSeconds = 3;
+        RampRateFinder finder = new RampRateFinder(workload);
+        long periodNanos = SECONDS.toNanos(3);
+
+        // A huge, transient apparent backlog during settling -- e.g. residual consumer-group
+        // rebalance catch-up right after startLoad() -- must not be evaluated at all.
+        boolean done = finder.poll(periodNanos, 100, 0);
+        assertThat(done).isFalse();
+        assertThat(finder.isSettled()).isFalse();
+        assertThat(finder.getLo()).isNull();
+        assertThat(finder.getHi()).isNull();
+
+        // 6s total elapsed -- settle threshold reached on this call, but this call only marks
+        // settled and resets the baseline; it doesn't evaluate backlog either.
+        done = finder.poll(periodNanos, 200, 100);
+        assertThat(done).isFalse();
+        assertThat(finder.isSettled()).isTrue();
+        assertThat(finder.getLo()).isNull();
+        assertThat(finder.getHi()).isNull();
+
+        // First real evaluation, using the baseline reset at the end of settling: clean.
+        done = finder.poll(periodNanos, 200 + 3000, 200 + 3000);
+        assertThat(done).isFalse();
+        assertThat(finder.getLo()).isEqualTo(1000.0);
     }
 
     @Test
     void bracketDoublesUntilBacklogThenTransitionsToChop() {
         Workload workload = workload();
         workload.rampStartRate = 1000;
+        workload.rampHoldSeconds = 3; // one poll completes a bracket hold too (default ties them)
         RampRateFinder finder = new RampRateFinder(workload);
         FakeSystem system = new FakeSystem(4500);
         long periodNanos = SECONDS.toNanos(3);
 
         assertThat(finder.getPhase()).isEqualTo(RampRateFinder.Phase.BRACKET);
+
+        finder.poll(periodNanos, 0, 0); // settle
+        assertThat(finder.isSettled()).isTrue();
 
         // 1000 -> clean, 2000 -> clean, 4000 -> clean, 8000 -> exceeds capacity
         for (int i = 0; i < 4; i++) {
@@ -79,10 +115,13 @@ class RampRateFinderTest {
     void holdFailsPartwayExitsEarlyWithoutWaitingOutTheFullHold() {
         Workload workload = workload();
         workload.rampStartRate = 1000;
-        workload.rampHoldSeconds = 30; // long hold -- a single failing poll must not wait this out
+        workload.rampBracketHoldSeconds = 3; // fast bracket setup
+        workload.rampHoldSeconds = 30; // long chop hold -- a single failing poll must not wait this out
         workload.rampConvergenceTolerance = 0.05;
         RampRateFinder finder = new RampRateFinder(workload);
         long periodNanos = SECONDS.toNanos(3);
+
+        finder.poll(periodNanos, 0, 0); // settle
 
         // Bracket: 1000 clean, 2000 exceeds -> CHOP with lo=1000, hi=2000, mid=1500
         finder.poll(periodNanos, 3000, 3000);
@@ -109,10 +148,12 @@ class RampRateFinderTest {
     void failedConfirmationReopensTheSearchInsteadOfAcceptingAnUnverifiedRate() {
         Workload workload = workload();
         workload.rampStartRate = 1000;
-        workload.rampHoldSeconds = 3; // one poll completes a hold
+        workload.rampHoldSeconds = 3; // one poll completes a hold (bracket and chop alike)
         workload.rampConvergenceTolerance = 0.5; // converge quickly for this test
         RampRateFinder finder = new RampRateFinder(workload);
         long periodNanos = SECONDS.toNanos(3);
+
+        finder.poll(periodNanos, 0, 0); // settle
 
         // Bracket: 1000 clean, 2000 exceeds -> CHOP, lo=1000, hi=2000, mid=1500
         finder.poll(periodNanos, 3000, 3000);
@@ -169,6 +210,7 @@ class RampRateFinderTest {
         RampRateFinder finder = new RampRateFinder(workload);
         long periodNanos = SECONDS.toNanos(3);
 
+        finder.poll(periodNanos, 0, 0); // settle
         finder.poll(periodNanos, 3000, 3000); // bracket: 1000 clean
         finder.poll(periodNanos, 6000, 6000); // bracket: 2000 exceeds -> CHOP mid=1500
 
@@ -195,6 +237,7 @@ class RampRateFinderTest {
         Workload absolute = workload();
         absolute.rampStartRate = 100000;
         RampRateFinder absoluteFinder = new RampRateFinder(absolute);
+        absoluteFinder.poll(periodNanos, 0, 0); // settle
         absoluteFinder.poll(periodNanos, 99500, 99500);
         assertThat(absoluteFinder.getHi()).isEqualTo(100000.0); // absolute limit (100) blown
         assertThat(absoluteFinder.getLo()).isNull();
@@ -202,7 +245,9 @@ class RampRateFinderTest {
         Workload relative = workload();
         relative.rampStartRate = 100000;
         relative.rampMaxBacklogSeconds = 0.01; // 1,000 messages allowed at this rate
+        relative.rampBracketHoldSeconds = 1; // one poll completes the hold for a clean verdict
         RampRateFinder relativeFinder = new RampRateFinder(relative);
+        relativeFinder.poll(periodNanos, 0, 0); // settle
         relativeFinder.poll(periodNanos, 99500, 99500);
         // Same backlog, but well under the rate-scaled limit -> treated as clean instead.
         assertThat(relativeFinder.getLo()).isEqualTo(100000.0);
@@ -213,17 +258,22 @@ class RampRateFinderTest {
     void safetyCapForcesCompletionWithBestKnownRate() {
         Workload workload = workload();
         workload.rampStartRate = 1000;
-        workload.rampMaxDiscoveryMinutes = 1;
+        workload.rampHoldSeconds = 10;
+        workload.rampMaxDiscoveryMinutes = 1; // 60s cap
         RampRateFinder finder = new RampRateFinder(workload);
 
-        // First poll: clean, establishes lo=1000, well within the 60s cap.
-        boolean done = finder.poll(SECONDS.toNanos(30), 30000, 30000);
+        // First poll consumes the (zero-length, per workload()) settle step.
+        boolean done = finder.poll(SECONDS.toNanos(10), 10000, 10000);
+        assertThat(done).isFalse();
+        assertThat(finder.getLo()).isNull();
+
+        // Second poll: one full 10s hold at 1000, clean -> lo=1000. Total elapsed 20s, within cap.
+        done = finder.poll(SECONDS.toNanos(10), 20000, 20000);
         assertThat(done).isFalse();
         assertThat(finder.getLo()).isEqualTo(1000.0);
 
-        // Second poll pushes total elapsed time past the 60s cap -- forces completion
-        // regardless of what the counters say.
-        done = finder.poll(SECONDS.toNanos(40), 30000, 30000);
+        // Third poll pushes total elapsed time past the 60s cap -- forces completion regardless.
+        done = finder.poll(SECONDS.toNanos(45), 20000, 20000);
 
         assertThat(done).isTrue();
         assertThat(finder.getPhase()).isEqualTo(RampRateFinder.Phase.DONE);
@@ -236,18 +286,21 @@ class RampRateFinderTest {
     void safetyCapDuringAPendingConfirmationHoldIsNotTreatedAsAConfirm() {
         Workload workload = workload();
         workload.rampStartRate = 1000;
-        workload.rampHoldSeconds = 30;
+        workload.rampBracketHoldSeconds = 3; // fast bracket setup
+        workload.rampHoldSeconds = 30; // slow chop hold (applies to first pass and confirmation)
         workload.rampConvergenceTolerance = 0.5;
         workload.rampMaxDiscoveryMinutes = 1; // 60s cap
         RampRateFinder finder = new RampRateFinder(workload);
         FakeSystem system = new FakeSystem(1800); // 1500 (candidate) stays clean, 2000 doesn't
         long periodNanos = SECONDS.toNanos(3);
 
-        // Bracket (2 polls, 6s) -> CHOP mid=1500. First hold (10 polls, 30s, total 36s) passes
-        // and is within tolerance -> confirming flips true at the 12th poll. The confirmation
-        // hold then needs another 30s (total 66s), but the 60s safety cap fires first (20th poll).
+        finder.poll(periodNanos, 0, 0); // settle
+
+        // Bracket (2 polls) -> CHOP mid=1500. First hold (10 polls, 30s) passes and is within
+        // tolerance -> confirming flips true. The confirmation hold then needs another 30s, but
+        // the 60s safety cap fires first, partway through it.
         boolean done = false;
-        for (int i = 0; i < 20 && !done; i++) {
+        for (int i = 0; i < 25 && !done; i++) {
             system.advance(finder.getCurrentRate(), periodNanos);
             done = finder.poll(periodNanos, system.totalPublished, system.totalReceived);
         }

--- a/benchmark-framework/src/test/java/io/openmessaging/benchmark/RampRateFinderTest.java
+++ b/benchmark-framework/src/test/java/io/openmessaging/benchmark/RampRateFinderTest.java
@@ -255,6 +255,59 @@ class RampRateFinderTest {
     }
 
     @Test
+    void uncappedRelativeLimitCanRunAwayAtHighCandidateRates() {
+        // The incident this guards against: at 1,000,000 msg/s with rampMaxBacklogSeconds=1.0,
+        // the relative limit alone would tolerate a full 1,000,000-message backlog -- so a
+        // candidate that only actually published 5,000 of an expected 1,000,000 messages (a
+        // massive shortfall) still gets called "clean" without a ceiling low enough to catch it.
+        Workload workload = workload();
+        workload.rampStartRate = 1000000;
+        workload.rampMaxBacklogSeconds = 1.0;
+        workload.rampMaxBacklogCeiling = 2_000_000L; // high enough not to clamp anything here
+        workload.rampBracketHoldSeconds = 1; // one poll completes the hold for a clean verdict
+        RampRateFinder finder = new RampRateFinder(workload);
+        long periodNanos = SECONDS.toNanos(1);
+
+        finder.poll(periodNanos, 0, 0); // settle
+        finder.poll(periodNanos, 5000, 5000);
+
+        assertThat(finder.getLo()).isEqualTo(1000000.0); // wrongly "clean"
+        assertThat(finder.getHi()).isNull();
+    }
+
+    @Test
+    void backlogCeilingCapsTheRelativeLimitAtHighCandidateRates() {
+        Workload workload = workload();
+        workload.rampStartRate = 1000000;
+        workload.rampMaxBacklogSeconds = 1.0; // would allow 1,000,000 messages without a ceiling
+        workload.rampMaxBacklogCeiling = 1000L; // deliberately low so the cap is what decides
+        RampRateFinder finder = new RampRateFinder(workload);
+        long periodNanos = SECONDS.toNanos(1);
+
+        finder.poll(periodNanos, 0, 0); // settle
+        finder.poll(periodNanos, 5000, 5000); // same massive shortfall as above
+
+        assertThat(finder.getHi()).isEqualTo(1000000.0); // caught by the ceiling this time
+        assertThat(finder.getLo()).isNull();
+    }
+
+    @Test
+    void backlogCeilingDefaultsTo100000MessagesWhenUnset() {
+        Workload workload = workload();
+        workload.rampStartRate = 1000000;
+        workload.rampMaxBacklogSeconds = 1.0; // would allow 1,000,000 messages without a ceiling
+        RampRateFinder finder = new RampRateFinder(workload); // rampMaxBacklogCeiling left unset
+        long periodNanos = SECONDS.toNanos(1);
+
+        finder.poll(periodNanos, 0, 0); // settle
+        finder.poll(periodNanos, 5000, 5000);
+
+        // The default ceiling (100,000) applies since none was set, catching the runaway
+        // tolerance just like an explicit low ceiling would.
+        assertThat(finder.getHi()).isEqualTo(1000000.0);
+    }
+
+    @Test
     void safetyCapForcesCompletionWithBestKnownRate() {
         Workload workload = workload();
         workload.rampStartRate = 1000;

--- a/benchmark-framework/src/test/java/io/openmessaging/benchmark/RampRateFinderTest.java
+++ b/benchmark-framework/src/test/java/io/openmessaging/benchmark/RampRateFinderTest.java
@@ -424,6 +424,54 @@ class RampRateFinderTest {
         assertThat(finder.isConfirmed()).isFalse();
     }
 
+    @Test
+    void aHoldShorterThanTheBrokerBurstBudgetWronglyAcceptsAnOversubscribedRate() {
+        // Sustained capacity is 1000 msg/s, but the broker can absorb a 4000-message burst before
+        // any backpressure shows (page cache / batching / socket buffers -- what FakeSystem's
+        // instantaneous hard cap cannot model). At a 2000 msg/s candidate the burst buffer fills in
+        // 4000 / (2000 - 1000) = 4 seconds, so a hold shorter than that sees only clean polls and
+        // wrongly accepts 2000 msg/s as sustainable. This is the over-confirm the Kafka integration
+        // test reproduced against a real bursting broker with short holds.
+        Workload workload = workload();
+        workload.rampStartRate = 2000;
+        workload.rampBracketHoldSeconds = 3; // shorter than the 4s burst-fill time
+        RampRateFinder finder = new RampRateFinder(workload);
+        FakeBurstySystem system = new FakeBurstySystem(1000, 4000);
+        long periodNanos = SECONDS.toNanos(1);
+
+        finder.poll(periodNanos, 0, 0); // settle
+        for (int i = 0; i < 3; i++) {
+            system.advance(finder.getCurrentRate(), periodNanos);
+            finder.poll(periodNanos, system.totalPublished, system.totalReceived);
+        }
+
+        assertThat(finder.getLo()).isEqualTo(2000.0); // oversubscribed rate accepted as clean
+    }
+
+    @Test
+    void aHoldLongerThanTheBurstBudgetCorrectlyRejectsTheOversubscribedRate() {
+        // Identical bursty broker, but a hold longer than the 4s burst-fill time: once the buffer
+        // saturates, publishes fall behind and the same 2000 msg/s candidate is correctly failed.
+        // The only difference from the test above is rampBracketHoldSeconds -- proving hold length
+        // is the lever, which no hold length could have revealed against FakeSystem's hard cap.
+        Workload workload = workload();
+        workload.rampStartRate = 2000;
+        workload.rampBracketHoldSeconds = 6; // longer than the 4s burst-fill time
+        RampRateFinder finder = new RampRateFinder(workload);
+        FakeBurstySystem system = new FakeBurstySystem(1000, 4000);
+        long periodNanos = SECONDS.toNanos(1);
+
+        finder.poll(periodNanos, 0, 0); // settle
+        boolean done = false;
+        for (int i = 0; i < 6 && !done; i++) {
+            system.advance(finder.getCurrentRate(), periodNanos);
+            done = finder.poll(periodNanos, system.totalPublished, system.totalReceived);
+        }
+
+        assertThat(finder.getHi()).isEqualTo(2000.0); // correctly failed once the burst drained
+        assertThat(finder.getLo()).isNull(); // never accepted as a clean lo
+    }
+
     /** A simple producer-limited system: throughput is capped at {@code capacity} msgs/sec. */
     private static final class FakeSystem {
         private final double capacity;
@@ -439,6 +487,37 @@ class RampRateFinderTest {
             long sent = (long) (Math.min(rate, capacity) * periodSeconds);
             totalPublished += sent;
             totalReceived += sent;
+        }
+    }
+
+    /**
+     * A broker that absorbs a burst above its sustained capacity into a finite buffer before any
+     * backpressure appears -- a leaky bucket, unlike {@link FakeSystem}'s instantaneous hard cap. An
+     * oversubscribed rate therefore looks clean until the buffer saturates, so whether the rate
+     * finder detects it depends entirely on how long the candidate is held. This is the property that
+     * makes hold length matter, and the one the old hard-cap model could not express.
+     */
+    private static final class FakeBurstySystem {
+        private final double sustainedCapacity;
+        private final double burstBudget;
+        private double buffer = 0;
+        long totalPublished = 0;
+        long totalReceived = 0;
+
+        FakeBurstySystem(double sustainedCapacity, double burstBudget) {
+            this.sustainedCapacity = sustainedCapacity;
+            this.burstBudget = burstBudget;
+        }
+
+        void advance(double rate, long periodNanos) {
+            double periodSeconds = periodNanos / 1e9;
+            double arrived = rate * periodSeconds;
+            double drained = sustainedCapacity * periodSeconds;
+            // Each period the broker can publish what it drains plus whatever free buffer remains.
+            double accepted = Math.min(arrived, drained + (burstBudget - buffer));
+            buffer = Math.max(0, Math.min(burstBudget, buffer + accepted - drained));
+            totalPublished += (long) accepted;
+            totalReceived += (long) accepted;
         }
     }
 }

--- a/benchmark-framework/src/test/java/io/openmessaging/benchmark/RampRateFinderTest.java
+++ b/benchmark-framework/src/test/java/io/openmessaging/benchmark/RampRateFinderTest.java
@@ -308,6 +308,64 @@ class RampRateFinderTest {
     }
 
     @Test
+    void uncappedRelativeLimitCanBecomeStricterThanUsefulAtLowRates() {
+        // The symmetric incident to the ceiling one above: at a low candidate rate,
+        // rampMaxBacklogSeconds alone gives a tiny tolerance -- smaller than a fixed-count check
+        // would ever have been -- so an ordinary, harmless blip gets treated as a capacity
+        // failure. Without a floor high enough to catch it, one such false failure (which halves
+        // the rate, and in the same stroke halves the tolerance again) can cascade all the way
+        // down to a near-zero "confirmed" rate.
+        Workload workload = workload();
+        workload.rampStartRate = 100;
+        workload.rampMaxBacklogSeconds = 0.1; // limit would be only 10 messages at this rate
+        workload.rampMaxBacklogFloor = 1L; // deliberately low so the floor isn't what saves this
+        RampRateFinder finder = new RampRateFinder(workload);
+        long periodNanos = SECONDS.toNanos(1);
+
+        finder.poll(periodNanos, 0, 0); // settle
+        finder.poll(periodNanos, 50, 50); // only 50 of the expected 100 published
+
+        assertThat(finder.getHi()).isEqualTo(100.0); // wrongly treated as a capacity failure
+        assertThat(finder.getLo()).isNull();
+    }
+
+    @Test
+    void backlogFloorPreventsToleranceFromShrinkingBelowFloorAtLowRates() {
+        Workload workload = workload();
+        workload.rampStartRate = 100;
+        workload.rampMaxBacklogSeconds = 0.1; // limit would be only 10 messages without a floor
+        workload.rampMaxBacklogFloor = 1000L;
+        workload.rampBracketHoldSeconds = 1; // one poll completes the hold for a clean verdict
+        RampRateFinder finder = new RampRateFinder(workload);
+        long periodNanos = SECONDS.toNanos(1);
+
+        finder.poll(periodNanos, 0, 0); // settle
+        finder.poll(periodNanos, 50, 50); // same shortfall as above
+
+        // The floor applies, so the same modest shortfall is correctly tolerated as clean.
+        assertThat(finder.getLo()).isEqualTo(100.0);
+        assertThat(finder.getHi()).isNull();
+    }
+
+    @Test
+    void backlogFloorDefaultsTo1000MessagesWhenUnset() {
+        Workload workload = workload();
+        workload.rampStartRate = 100;
+        workload.rampMaxBacklogSeconds = 0.1; // limit would be only 10 messages without a floor
+        workload.rampBracketHoldSeconds = 1; // one poll completes the hold for a clean verdict
+        RampRateFinder finder = new RampRateFinder(workload); // rampMaxBacklogFloor left unset
+        long periodNanos = SECONDS.toNanos(1);
+
+        finder.poll(periodNanos, 0, 0); // settle
+        // 800 messages of cumulative receive backlog -- below the default floor (1000) but would
+        // exceed a smaller one (e.g. 500), pinning the default's exact value.
+        finder.poll(periodNanos, 800, 0);
+
+        assertThat(finder.getLo()).isEqualTo(100.0);
+        assertThat(finder.getHi()).isNull();
+    }
+
+    @Test
     void safetyCapForcesCompletionWithBestKnownRate() {
         Workload workload = workload();
         workload.rampStartRate = 1000;

--- a/benchmark-framework/src/test/java/io/openmessaging/benchmark/RampRateFinderTest.java
+++ b/benchmark-framework/src/test/java/io/openmessaging/benchmark/RampRateFinderTest.java
@@ -68,6 +68,8 @@ class RampRateFinderTest {
         assertThat(done).isTrue();
         assertThat(finder.getPhase()).isEqualTo(RampRateFinder.Phase.DONE);
         assertThat(finder.isNonMonotonic()).isFalse();
+        assertThat(finder.isConfirming()).isTrue();
+        assertThat(finder.isConfirmed()).isTrue();
         // The backlog limit tolerates a small overshoot past true capacity before it's detected,
         // so the discovered rate lands just above 4500, not below it -- assert closeness instead.
         assertThat(Math.abs(4500.0 - finder.getCurrentRate()) / 4500.0).isLessThan(0.05);
@@ -98,6 +100,9 @@ class RampRateFinderTest {
         assertThat(done).isFalse();
         assertThat(finder.getHi()).isEqualTo(1500.0);
         assertThat(finder.getCurrentRate()).isEqualTo((1000.0 + 1500.0) / 2.0);
+        // Tolerance was never met, so the confirmation hold was never entered.
+        assertThat(finder.isConfirming()).isFalse();
+        assertThat(finder.isConfirmed()).isFalse();
     }
 
     @Test
@@ -113,12 +118,16 @@ class RampRateFinderTest {
         finder.poll(periodNanos, 3000, 3000);
         finder.poll(periodNanos, 6000, 6000);
         assertThat(finder.getPhase()).isEqualTo(RampRateFinder.Phase.CHOP);
+        assertThat(finder.isConfirming()).isFalse();
 
         // Hold at 1500 passes cleanly -- within tolerance (500/1500 = 0.33 <= 0.5), so this
-        // triggers the one-more confirmation hold at the same rate rather than DONE yet.
+        // triggers the one-more confirmation hold at the same rate rather than DONE yet. This is
+        // the poll() call where isConfirming() flips false -> true.
         boolean done = finder.poll(periodNanos, 6000 + 4500, 6000 + 4500);
         assertThat(done).isFalse();
         assertThat(finder.getCurrentRate()).isEqualTo(1500.0);
+        assertThat(finder.isConfirming()).isTrue();
+        assertThat(finder.isConfirmed()).isFalse();
 
         // Confirmation hold at the same rate (1500) now shows a backlog breach -- a direct
         // contradiction of the pass just recorded at the same rate.
@@ -127,6 +136,10 @@ class RampRateFinderTest {
         assertThat(done).isTrue();
         assertThat(finder.getPhase()).isEqualTo(RampRateFinder.Phase.DONE);
         assertThat(finder.isNonMonotonic()).isTrue();
+        // Rejected on the confirmation hold, not accepted -- confirmed must stay false even
+        // though confirming (the "we were attempting a confirm" flag) is still true.
+        assertThat(finder.isConfirming()).isTrue();
+        assertThat(finder.isConfirmed()).isFalse();
     }
 
     @Test
@@ -148,6 +161,36 @@ class RampRateFinderTest {
         assertThat(done).isTrue();
         assertThat(finder.getPhase()).isEqualTo(RampRateFinder.Phase.DONE);
         assertThat(finder.getCurrentRate()).isEqualTo(1000.0);
+        // The safety cap is never a genuine confirm, even though it never contradicted anything.
+        assertThat(finder.isConfirmed()).isFalse();
+    }
+
+    @Test
+    void safetyCapDuringAPendingConfirmationHoldIsNotTreatedAsAConfirm() {
+        Workload workload = workload();
+        workload.rampStartRate = 1000;
+        workload.rampHoldSeconds = 30;
+        workload.rampConvergenceTolerance = 0.5;
+        workload.rampMaxDiscoveryMinutes = 1; // 60s cap
+        RampRateFinder finder = new RampRateFinder(workload);
+        FakeSystem system = new FakeSystem(1800); // 1500 (candidate) stays clean, 2000 doesn't
+        long periodNanos = SECONDS.toNanos(3);
+
+        // Bracket (2 polls, 6s) -> CHOP mid=1500. First hold (10 polls, 30s, total 36s) passes
+        // and is within tolerance -> confirming flips true at the 12th poll. The confirmation
+        // hold then needs another 30s (total 66s), but the 60s safety cap fires first (20th poll).
+        boolean done = false;
+        for (int i = 0; i < 20 && !done; i++) {
+            system.advance(finder.getCurrentRate(), periodNanos);
+            done = finder.poll(periodNanos, system.totalPublished, system.totalReceived);
+        }
+
+        assertThat(done).isTrue();
+        assertThat(finder.getPhase()).isEqualTo(RampRateFinder.Phase.DONE);
+        assertThat(finder.isConfirming()).isTrue();
+        // The confirmation hold was still pending when the safety cap forced completion --
+        // that must not be mistaken for a genuine confirm.
+        assertThat(finder.isConfirmed()).isFalse();
     }
 
     /** A simple producer-limited system: throughput is capped at {@code capacity} msgs/sec. */

--- a/docs/superpowers/plans/2026-07-24-chop-throughput-verdict.md
+++ b/docs/superpowers/plans/2026-07-24-chop-throughput-verdict.md
@@ -1,0 +1,633 @@
+# CHOP `THROUGHPUT` verdict — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in `rampVerdict: THROUGHPUT` mode to CHOP that decides a candidate rate's pass/fail from scale-free achieved-rate and consumer-drain ratios instead of an absolute backlog-message count.
+
+**Architecture:** Introduce a `RampVerdict` enum and two `Workload` fields. Refactor `RampRateFinder` so the per-hold clean/exceeded decision goes through a small `holdClean()` seam — preserving today's `BACKLOG` behavior byte-for-byte — then implement the `THROUGHPUT` seam using per-hold accumulated `expected`/`published`/`received`. All bracket/chop/confirm/reopen/safety-cap machinery is reused unchanged.
+
+**Tech Stack:** Java 17, JUnit 5, AssertJ, Maven (surefire unit + failsafe IT), Testcontainers (Kafka), Lombok.
+
+## Global Constraints
+
+- Java 17 (repo pins `17.0.14-tem` via `.sdkmanrc`); `mvn` must run under JDK 17.
+- Default `rampVerdict: BACKLOG` ⇒ **zero behavior change**; all 17 existing `RampRateFinderTest` cases must stay green after every task.
+- `rampMinThroughputRatio` default `0.95`.
+- No new `Worker` API (finder already receives cumulative `totalPublished`/`totalReceived`).
+- `spotless:check`, `checkstyle`, `spotbugs` must pass (`mvn -pl benchmark-framework verify`); run `mvn -pl benchmark-framework spotless:apply` before committing.
+- The Testcontainers IT stays gated: skipped by default, runs under `-Pintegration-tests`.
+- Reuse the existing state machine — do not alter bracket doubling/halving, chop bisection, confirmation holds, reopen-on-failed-confirm, `finishWithBestKnown`, or `recordVerdict`/`nonMonotonic`.
+
+## File Structure
+
+- **Create** `benchmark-framework/src/main/java/io/openmessaging/benchmark/RampVerdict.java` — the mode enum (mirrors `RampAlgorithm`).
+- **Modify** `benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java` — add `rampVerdict`, `rampMinThroughputRatio`.
+- **Modify** `benchmark-framework/src/main/java/io/openmessaging/benchmark/RampRateFinder.java` — verdict seam + throughput predicate.
+- **Modify** `benchmark-framework/src/test/java/io/openmessaging/benchmark/RampRateFinderTest.java` — throughput unit tests + fakes.
+- **Modify** `benchmark-framework/src/test/java/io/openmessaging/benchmark/ChopRateFinderKafkaIT.java` — `THROUGHPUT` IT variant.
+- **Modify** `benchmark-framework/RATE_FINDING.md` — document both verdict modes + the AKS motivation.
+
+---
+
+### Task 1: `RampVerdict` enum + `Workload` fields
+
+**Files:**
+- Create: `benchmark-framework/src/main/java/io/openmessaging/benchmark/RampVerdict.java`
+- Modify: `benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java`
+- Test: `benchmark-framework/src/test/java/io/openmessaging/benchmark/WorkloadVerdictDefaultsTest.java` (create)
+
+**Interfaces:**
+- Produces: `enum RampVerdict { BACKLOG, THROUGHPUT }`; `Workload.rampVerdict` (default `BACKLOG`), `Workload.rampMinThroughputRatio` (`Double`, nullable).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `WorkloadVerdictDefaultsTest.java`:
+
+```java
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); ... (copy the standard
+ * license header used by the other files in this package)
+ */
+package io.openmessaging.benchmark;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class WorkloadVerdictDefaultsTest {
+    @Test
+    void rampVerdictDefaultsToBacklogAndRatioIsUnsetByDefault() {
+        Workload workload = new Workload();
+        assertThat(workload.rampVerdict).isEqualTo(RampVerdict.BACKLOG);
+        assertThat(workload.rampMinThroughputRatio).isNull();
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mvn -pl benchmark-framework test -Dtest=WorkloadVerdictDefaultsTest -Dspotless.check.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Denforcer.skip=true`
+Expected: FAIL to compile — `RampVerdict` / fields do not exist.
+
+- [ ] **Step 3: Create the enum**
+
+`RampVerdict.java` (mirror `RampAlgorithm.java`, same license header):
+
+```java
+package io.openmessaging.benchmark;
+
+/** How CHOP decides whether a held candidate rate is sustainable. See RATE_FINDING.md. */
+public enum RampVerdict {
+    /** Original: a candidate fails if publish/receive backlog exceeds a message-count limit. */
+    BACKLOG,
+    /** Achieved-rate + consumer-drain ratios (scale-free). */
+    THROUGHPUT
+}
+```
+
+- [ ] **Step 4: Add the `Workload` fields**
+
+In `Workload.java`, next to the other `ramp*` fields (after `rampAlgorithm`), add:
+
+```java
+    public RampVerdict rampVerdict = RampVerdict.BACKLOG;
+
+    // Minimum fraction of target throughput (and of consumer drain) a candidate must achieve over a
+    // hold to count as clean under rampVerdict: THROUGHPUT. Null -> default 0.95 in RampRateFinder.
+    public Double rampMinThroughputRatio;
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `mvn -pl benchmark-framework test -Dtest=WorkloadVerdictDefaultsTest -Dspotless.check.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Denforcer.skip=true`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+mvn -pl benchmark-framework spotless:apply
+git add benchmark-framework/src/main/java/io/openmessaging/benchmark/RampVerdict.java \
+        benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java \
+        benchmark-framework/src/test/java/io/openmessaging/benchmark/WorkloadVerdictDefaultsTest.java
+git commit -m "feat(ramp): add RampVerdict enum and workload fields"
+```
+
+---
+
+### Task 2: Refactor `RampRateFinder` to a `breachedNow` + `holdClean()` seam (BACKLOG-preserving)
+
+Pure refactor: route the pass/fail decision through a `holdClean()` method that returns `true` for `BACKLOG` (a breach already fast-fails per-poll, so hold completion == clean today). No behavior change; the existing 17 tests are the regression gate.
+
+**Files:**
+- Modify: `benchmark-framework/src/main/java/io/openmessaging/benchmark/RampRateFinder.java`
+- Test: `benchmark-framework/src/test/java/io/openmessaging/benchmark/RampRateFinderTest.java` (existing, unchanged — used as the gate)
+
+**Interfaces:**
+- Produces (private): `boolean holdClean()`; `pollBracket(boolean breachedNow, long periodNanos)`, `pollChop(boolean breachedNow, long periodNanos)`.
+
+- [ ] **Step 1: Add the `holdClean()` seam and a verdict field**
+
+Add field near the other `final` config fields (top of class):
+
+```java
+    private final RampVerdict verdict;
+```
+
+In the constructor (after `requiredConfirmationHolds` is set):
+
+```java
+        this.verdict = workload.rampVerdict != null ? workload.rampVerdict : RampVerdict.BACKLOG;
+```
+
+Add the seam (place it just above `recordVerdict`):
+
+```java
+    // Whether the just-completed hold counts as clean. For BACKLOG this is always true: a real
+    // breach fast-fails per-poll before the hold ever completes, so reaching completion means clean.
+    // THROUGHPUT overrides this in a later task.
+    private boolean holdClean() {
+        return true;
+    }
+```
+
+- [ ] **Step 2: Rewrite `pollBracket` to branch on `holdClean()` at completion**
+
+Replace the whole `pollBracket` method with (behavior-identical for BACKLOG — `failed` collapses to `breachedNow` since `holdClean()` is `true`):
+
+```java
+    private boolean pollBracket(boolean breachedNow, long periodNanos) {
+        boolean failed;
+        if (breachedNow) {
+            failed = true;
+        } else {
+            elapsedHoldNanos += periodNanos;
+            if (elapsedHoldNanos < bracketHoldNanos) {
+                return false;
+            }
+            failed = !holdClean();
+        }
+        elapsedHoldNanos = 0;
+        recordVerdict(currentRate, !failed);
+        if (failed) {
+            hi = currentRate;
+        } else {
+            lo = currentRate;
+        }
+
+        if (lo != null && hi != null) {
+            phase = Phase.CHOP;
+            currentRate = (lo + hi) / 2.0;
+            return false;
+        }
+
+        bracketIterations++;
+        if (bracketIterations >= MAX_BRACKET_ITERATIONS) {
+            finishWithBestKnown();
+            return true;
+        }
+
+        currentRate = failed ? currentRate / 2.0 : currentRate * 2.0;
+        return false;
+    }
+```
+
+- [ ] **Step 3: Rewrite `pollChop` to branch on `holdClean()` at completion**
+
+Replace the whole `pollChop` method with (the failed path is the former `backlogExceeded` path verbatim; the clean path is the former completion path verbatim):
+
+```java
+    private boolean pollChop(boolean breachedNow, long periodNanos) {
+        boolean failed;
+        if (breachedNow) {
+            failed = true;
+        } else {
+            elapsedHoldNanos += periodNanos;
+            if (elapsedHoldNanos < holdNanos) {
+                return false;
+            }
+            failed = !holdClean();
+        }
+
+        if (failed) {
+            recordVerdict(currentRate, false);
+            elapsedHoldNanos = 0;
+            if (confirming) {
+                hi = currentRate;
+                lo = bestKnownPassBelow(hi);
+                confirming = false;
+                confirmationHoldsPassed = 0;
+                currentRate = (lo + hi) / 2.0;
+                return false;
+            }
+            hi = currentRate;
+            currentRate = (lo + hi) / 2.0;
+            return false;
+        }
+
+        recordVerdict(currentRate, true);
+        elapsedHoldNanos = 0;
+        if (!confirming) {
+            lo = currentRate;
+        }
+
+        if ((hi - lo) / lo <= convergenceTolerance) {
+            if (!confirming) {
+                confirming = true;
+                confirmationHoldsPassed = 0;
+                currentRate = lo;
+                return false;
+            }
+            confirmationHoldsPassed++;
+            if (confirmationHoldsPassed >= requiredConfirmationHolds) {
+                currentRate = lo;
+                confirmed = true;
+                phase = Phase.DONE;
+                return true;
+            }
+            currentRate = lo;
+            return false;
+        }
+
+        confirming = false;
+        currentRate = (lo + hi) / 2.0;
+        return false;
+    }
+```
+
+- [ ] **Step 4: Rename the `poll()` dispatch variable for clarity**
+
+In `poll()`, the local currently named `backlogExceeded` is the per-poll fast-fail signal. Rename it to `breachedNow` at its declaration and both `pollBracket`/`pollChop` call sites (lines ~165 and ~189). The computation (the `maxBacklogSeconds` / else block) is unchanged in this task.
+
+```java
+        boolean breachedNow;
+        if (maxBacklogSeconds != null) {
+            double limit =
+                    Math.max(
+                            maxBacklogFloor,
+                            Math.min(currentRate * maxBacklogSeconds, (double) maxBacklogCeiling));
+            breachedNow = receiveBacklog > limit || publishBacklog > limit;
+        } else {
+            breachedNow =
+                    receiveBacklog > receiveBacklogLimit || publishBacklog > publishBacklogLimit;
+        }
+
+        return phase == Phase.BRACKET
+                ? pollBracket(breachedNow, periodNanos)
+                : pollChop(breachedNow, periodNanos);
+```
+
+- [ ] **Step 5: Run the full existing finder suite to verify no behavior change**
+
+Run: `mvn -pl benchmark-framework test -Dtest=RampRateFinderTest -Dspotless.check.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Denforcer.skip=true`
+Expected: PASS — `Tests run: 17, Failures: 0, Errors: 0`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+mvn -pl benchmark-framework spotless:apply
+git add benchmark-framework/src/main/java/io/openmessaging/benchmark/RampRateFinder.java
+git commit -m "refactor(ramp): route verdict through holdClean() seam (no behavior change)"
+```
+
+---
+
+### Task 3: Implement the `THROUGHPUT` verdict + unit tests
+
+Add per-hold accumulation and the ratio predicate. For `THROUGHPUT`, `breachedNow` is always `false` (verdict decided at hold completion) and `holdClean()` uses the accumulated ratios.
+
+**Files:**
+- Modify: `benchmark-framework/src/main/java/io/openmessaging/benchmark/RampRateFinder.java`
+- Test: `benchmark-framework/src/test/java/io/openmessaging/benchmark/RampRateFinderTest.java`
+
+**Interfaces:**
+- Consumes: `RampVerdict`, `verdict`, `holdClean()` seam (Task 2), `Workload.rampMinThroughputRatio` (Task 1).
+
+- [ ] **Step 1: Write the failing throughput unit tests**
+
+Append to `RampRateFinderTest.java` (before the trailing `}`), plus a shared helper `throughputWorkload()` and two fakes:
+
+```java
+    private static Workload throughputWorkload() {
+        Workload workload = new Workload();
+        workload.rampVerdict = RampVerdict.THROUGHPUT;
+        workload.rampMinThroughputRatio = 0.95;
+        workload.rampSettleSeconds = 0;
+        workload.rampBracketHoldSeconds = 1; // one 1s poll completes a hold
+        workload.rampHoldSeconds = 1;
+        workload.rampConvergenceTolerance = 0.05;
+        return workload;
+    }
+
+    @Test
+    void throughputVerdictConvergesNearProducerCapacity() {
+        Workload workload = throughputWorkload();
+        workload.rampStartRate = 1000;
+        RampRateFinder finder = new RampRateFinder(workload);
+        // Producer caps at 4500 msg/s; consumer never the bottleneck.
+        FakeThroughputSystem system = new FakeThroughputSystem(4500, 1_000_000_000L, 0);
+        long periodNanos = SECONDS.toNanos(1);
+
+        boolean done = false;
+        for (int i = 0; i < 200 && !done; i++) {
+            system.advance(finder.getCurrentRate(), periodNanos);
+            done = finder.poll(periodNanos, system.totalPublished, system.totalReceived);
+        }
+
+        assertThat(done).isTrue();
+        assertThat(finder.getPhase()).isEqualTo(RampRateFinder.Phase.DONE);
+        assertThat(Math.abs(4500.0 - finder.getCurrentRate()) / 4500.0).isLessThan(0.1);
+    }
+
+    @Test
+    void throughputVerdictRejectsRatesWhereTheConsumerCannotKeepUp() {
+        Workload workload = throughputWorkload();
+        workload.rampStartRate = 1000;
+        RampRateFinder finder = new RampRateFinder(workload);
+        // Producer could do 100k, but the consumer only drains 3000 msg/s -> consumer is the ceiling.
+        FakeThroughputSystem system = new FakeThroughputSystem(100_000, 3000, 0);
+        long periodNanos = SECONDS.toNanos(1);
+
+        boolean done = false;
+        for (int i = 0; i < 200 && !done; i++) {
+            system.advance(finder.getCurrentRate(), periodNanos);
+            done = finder.poll(periodNanos, system.totalPublished, system.totalReceived);
+        }
+
+        assertThat(done).isTrue();
+        // Discovery is pinned by consumer drain (~3000), far below producer capacity.
+        assertThat(finder.getCurrentRate()).isLessThan(6000.0);
+        assertThat(finder.getCurrentRate()).isGreaterThan(1500.0);
+    }
+
+    @Test
+    void throughputVerdictIgnoresLargeButStableInFlightBacklogThatACountLimitWouldReject() {
+        Workload workload = throughputWorkload();
+        workload.rampStartRate = 1000;
+        RampRateFinder finder = new RampRateFinder(workload);
+        // Producer caps at 50k; a stable 50,000-message in-flight backlog is always present, and the
+        // consumer merely keeps pace with it. A 1000-count receiveBacklog check would reject every
+        // rate; THROUGHPUT (drain ratio ~1.0) climbs to the real 50k ceiling.
+        FakeThroughputSystem system = new FakeThroughputSystem(50_000, 1_000_000_000L, 50_000);
+        long periodNanos = SECONDS.toNanos(1);
+
+        boolean done = false;
+        for (int i = 0; i < 400 && !done; i++) {
+            system.advance(finder.getCurrentRate(), periodNanos);
+            done = finder.poll(periodNanos, system.totalPublished, system.totalReceived);
+        }
+
+        assertThat(done).isTrue();
+        assertThat(Math.abs(50_000.0 - finder.getCurrentRate()) / 50_000.0).isLessThan(0.1);
+    }
+
+    /**
+     * A producer/consumer pair with independent sustained capacities and an optional pre-established,
+     * stable in-flight backlog (the consumer keeps pace with it but never closes it). Backlog is
+     * therefore large-but-constant when seeded -- the case an absolute-count verdict mishandles.
+     */
+    private static final class FakeThroughputSystem {
+        private final double producerCapacity;
+        private final double consumerCapacity;
+        long totalPublished;
+        long totalReceived;
+
+        FakeThroughputSystem(double producerCapacity, double consumerCapacity, long standingBacklog) {
+            this.producerCapacity = producerCapacity;
+            this.consumerCapacity = consumerCapacity;
+            this.totalPublished = standingBacklog; // seed a stable in-flight backlog
+            this.totalReceived = 0;
+        }
+
+        void advance(double rate, long periodNanos) {
+            double periodSeconds = periodNanos / 1e9;
+            totalPublished += (long) (Math.min(rate, producerCapacity) * periodSeconds);
+            long lag = totalPublished - totalReceived;
+            totalReceived += (long) Math.min(consumerCapacity * periodSeconds, lag);
+        }
+    }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `mvn -pl benchmark-framework test -Dtest=RampRateFinderTest -Dspotless.check.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Denforcer.skip=true`
+Expected: FAIL — the three new tests do not converge as asserted, because `holdClean()` still always returns `true` and `breachedNow` still uses the count check (so `THROUGHPUT` behaves like an unbounded-tolerance backlog run).
+
+- [ ] **Step 3: Add per-hold accumulation to `poll()`**
+
+Add fields (near `previousTotalPublished`):
+
+```java
+    private final double minThroughputRatio;
+    private long previousTotalReceived = 0;
+    private long holdExpected = 0;
+    private long holdPublished = 0;
+    private long holdReceived = 0;
+```
+
+In the constructor:
+
+```java
+        this.minThroughputRatio =
+                workload.rampMinThroughputRatio != null
+                        ? workload.rampMinThroughputRatio.doubleValue()
+                        : 0.95;
+```
+
+In `poll()`, inside the settle block, keep the received baseline current too (next to `previousTotalPublished = totalPublished;`):
+
+```java
+            previousTotalReceived = totalReceived;
+```
+
+After the per-period `published`/`receiveBacklog`/`publishBacklog` are computed and `previousTotalPublished` is updated, add received-delta tracking and hold accumulation:
+
+```java
+        long received = totalReceived - previousTotalReceived;
+        previousTotalReceived = totalReceived;
+
+        // A fresh hold starts whenever elapsedHoldNanos was reset to 0 by the previous poll's
+        // transition (or after settle). Reset the per-hold accumulators at that first poll.
+        if (elapsedHoldNanos == 0) {
+            holdExpected = 0;
+            holdPublished = 0;
+            holdReceived = 0;
+        }
+        holdExpected += expected;
+        holdPublished += published;
+        holdReceived += received;
+```
+
+- [ ] **Step 4: Make `breachedNow` mode-aware and implement `holdClean()`**
+
+In `poll()`, guard the fast-fail computation so `THROUGHPUT` never fast-fails:
+
+```java
+        boolean breachedNow;
+        if (verdict == RampVerdict.THROUGHPUT) {
+            breachedNow = false; // throughput verdict is decided at hold completion (see holdClean)
+        } else if (maxBacklogSeconds != null) {
+            double limit =
+                    Math.max(
+                            maxBacklogFloor,
+                            Math.min(currentRate * maxBacklogSeconds, (double) maxBacklogCeiling));
+            breachedNow = receiveBacklog > limit || publishBacklog > limit;
+        } else {
+            breachedNow =
+                    receiveBacklog > receiveBacklogLimit || publishBacklog > publishBacklogLimit;
+        }
+```
+
+Replace the `holdClean()` body from Task 2 with:
+
+```java
+    private boolean holdClean() {
+        if (verdict != RampVerdict.THROUGHPUT) {
+            return true;
+        }
+        boolean producerKeepsUp = holdPublished >= minThroughputRatio * holdExpected;
+        boolean consumerKeepsUp = holdReceived >= minThroughputRatio * holdPublished;
+        return producerKeepsUp && consumerKeepsUp;
+    }
+```
+
+- [ ] **Step 5: Run the full finder suite (new + existing)**
+
+Run: `mvn -pl benchmark-framework test -Dtest=RampRateFinderTest -Dspotless.check.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Denforcer.skip=true`
+Expected: PASS — the original 17 plus the 3 new throughput tests (`Tests run: 20`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+mvn -pl benchmark-framework spotless:apply
+git add benchmark-framework/src/main/java/io/openmessaging/benchmark/RampRateFinder.java \
+        benchmark-framework/src/test/java/io/openmessaging/benchmark/RampRateFinderTest.java
+git commit -m "feat(ramp): THROUGHPUT verdict (achieved-rate + consumer-drain ratios)"
+```
+
+---
+
+### Task 4: Document both verdict modes in `RATE_FINDING.md`
+
+**Files:**
+- Modify: `benchmark-framework/RATE_FINDING.md`
+
+- [ ] **Step 1: Add a "Verdict modes" subsection under CHOP**
+
+After the CHOP "Algorithm" section, add a subsection documenting `rampVerdict`:
+
+- `BACKLOG` (default): the existing backlog-count predicate (`rampMaxBacklogSeconds`/`Floor`/`Ceiling`, or the fixed `rampPublishBacklogLimit`/`rampReceiveBacklogLimit`). Note its structural weakness — a healthy pipeline's in-flight backlog scales with throughput, so any fixed-ish count is too strict at high rates and too loose at low ones.
+- `THROUGHPUT` (opt-in): per hold, `clean ⇔ published ≥ ratio·expected AND received ≥ ratio·published`, with `ratio = rampMinThroughputRatio` (default 0.95). Scale-free (one threshold at every rate); no fast-fail (verdict at hold completion). Note it does not solve hold-length sensitivity (a hold must exceed the broker's burst-absorption time in either mode).
+
+- [ ] **Step 2: Add the two new fields to the config table**
+
+Add rows for `rampVerdict` (default `BACKLOG`) and `rampMinThroughputRatio` (default `0.95`, "CHOP only — THROUGHPUT verdict").
+
+- [ ] **Step 3: Add a Trial-finding note recording the AKS motivation**
+
+Add a short subsection recording the 2026-07-24 AKS re-validation (run 30103329337): on one cluster, BACKLOG-based methods under-reported the true sustainable rate (AIMD ~13.5k, `chop-floor` 2,734) while a sustained ~880k held cleanly for 15 minutes — the evidence that motivated the scale-free THROUGHPUT verdict.
+
+- [ ] **Step 4: Verify formatting**
+
+Run: `mvn -pl benchmark-framework spotless:apply` then `git diff --stat benchmark-framework/RATE_FINDING.md`
+Expected: only `RATE_FINDING.md` reformatted (table column widths may adjust).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add benchmark-framework/RATE_FINDING.md
+git commit -m "docs(ramp): document BACKLOG vs THROUGHPUT verdict modes"
+```
+
+---
+
+### Task 5: Testcontainers IT `THROUGHPUT` variant
+
+Add an integration test proving `THROUGHPUT` converges to a sustainable rate at least as high as the `BACKLOG` path on the same broker (relative, machine-independent).
+
+**Files:**
+- Modify: `benchmark-framework/src/test/java/io/openmessaging/benchmark/ChopRateFinderKafkaIT.java`
+
+**Interfaces:**
+- Consumes: `RampVerdict.THROUGHPUT`, `Workload.rampMinThroughputRatio`; existing `discoveryWorkload()`, `writeKafkaDriverConfig(...)`, `KAFKA` container.
+
+- [ ] **Step 1: Add a helper that runs discovery and returns the confirmed rate + sustainability**
+
+Add to `ChopRateFinderKafkaIT`:
+
+```java
+    private double runDiscoveryAndAssertSustainable(Workload workload) throws Exception {
+        File driverConfig = writeKafkaDriverConfig(KAFKA.getBootstrapServers());
+        LocalWorker worker = new LocalWorker();
+        worker.initializeDriver(driverConfig);
+        TestResult result;
+        try (WorkloadGenerator generator = new WorkloadGenerator("Kafka", workload, worker)) {
+            result = generator.run();
+        }
+        double pubDelayAvgMs = result.aggregatedPublishDelayLatencyAvg / 1000.0;
+        log.info(
+                "verdict={} confirmedRate={} avgPublishDelay={} ms",
+                workload.rampVerdict,
+                result.rampVerification == null ? null : result.rampVerification.rate,
+                String.format("%.1f", pubDelayAvgMs));
+        assertThat(pubDelayAvgMs).isLessThan(500.0); // the confirmed rate must actually hold
+        return result.rampVerification == null ? 0.0 : result.rampVerification.rate;
+    }
+```
+
+- [ ] **Step 2: Write the failing THROUGHPUT test**
+
+```java
+    @Test
+    void throughputVerdictFindsASustainableRateAtLeastAsHighAsBacklog() throws Exception {
+        Workload backlog = discoveryWorkload();
+        double backlogRate = runDiscoveryAndAssertSustainable(backlog);
+
+        Workload throughput = discoveryWorkload();
+        throughput.rampVerdict = RampVerdict.THROUGHPUT;
+        throughput.rampMinThroughputRatio = 0.95;
+        double throughputRate = runDiscoveryAndAssertSustainable(throughput);
+
+        // THROUGHPUT must not under-report relative to the backlog-count path on the same broker.
+        assertThat(throughputRate).isGreaterThanOrEqualTo(backlogRate * 0.9);
+    }
+```
+
+- [ ] **Step 3: Run under the integration profile**
+
+Run: `mvn -pl benchmark-framework verify -Pintegration-tests -Dit.test=ChopRateFinderKafkaIT -Dsurefire.skip=true -Dspotless.check.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Denforcer.skip=true`
+Expected: PASS (Docker required). Both loads confirm sustainable rates; the throughput rate is ≥ 90% of the backlog rate. Note: this runs two discovery cycles — several minutes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+mvn -pl benchmark-framework spotless:apply
+git add benchmark-framework/src/test/java/io/openmessaging/benchmark/ChopRateFinderKafkaIT.java
+git commit -m "test(ramp): Testcontainers IT for THROUGHPUT verdict"
+```
+
+---
+
+### Task 6: Full verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Default build (IT skipped) — unit + static analysis**
+
+Run: `mvn -pl benchmark-framework verify`
+Expected: `BUILD SUCCESS`; `RampRateFinderTest` 20 tests; failsafe reports "Tests are skipped"; spotless/checkstyle/spotbugs clean.
+
+- [ ] **Step 2: Integration profile — IT runs**
+
+Run: `mvn -pl benchmark-framework verify -Pintegration-tests -Dit.test=ChopRateFinderKafkaIT -Dsurefire.skip=true`
+Expected: `BUILD SUCCESS`; both IT methods pass.
+
+- [ ] **Step 3: Multi-module sanity (optional, slower)**
+
+Run: `mvn -q -pl benchmark-framework -am install -DskipTests`
+Expected: `BUILD SUCCESS` — confirms the new enum/fields don't break dependents.
+
+## Self-Review
+
+- **Spec coverage:** `rampVerdict` enum + default BACKLOG (Task 1); `rampMinThroughputRatio` 0.95 (Tasks 1,3); predicate `published≥ratio·expected AND received≥ratio·published` at hold completion (Task 3 Step 4); no per-poll fast-fail for THROUGHPUT (`breachedNow=false`, Task 3 Step 4); machinery reused (Task 2 preserves it); no new Worker API (uses counters already passed to `poll`); back-compat default (Task 1 + Task 2 regression gate); tests unit+IT (Tasks 3,5); docs incl. AKS motivation + hold-length caveat (Task 4). All spec sections map to a task.
+- **Placeholder scan:** the only prose-only step is Task 4 (a Markdown doc, content described precisely by section); every code step shows complete code.
+- **Type consistency:** `RampVerdict.{BACKLOG,THROUGHPUT}`, `Workload.rampVerdict`/`rampMinThroughputRatio`, `holdClean()`, `breachedNow`, `holdExpected/holdPublished/holdReceived`, `previousTotalReceived`, `minThroughputRatio` used consistently across Tasks 1–3; `FakeThroughputSystem(double,double,long)` constructor matches all three call sites in Task 3 Step 1.

--- a/docs/superpowers/specs/2026-07-24-chop-throughput-verdict-design.md
+++ b/docs/superpowers/specs/2026-07-24-chop-throughput-verdict-design.md
@@ -1,0 +1,159 @@
+# CHOP `THROUGHPUT` verdict — design
+
+- **Date:** 2026-07-24
+- **Status:** Design approved; implementation not started
+- **Component:** `benchmark-framework` — `RampRateFinder` (opt-in CHOP rate finder), PR #19
+- **Related:** `benchmark-framework/RATE_FINDING.md`; the two "Trial finding" incidents recorded there
+
+## Context
+
+CHOP discovers a sustainable producer rate by holding a candidate rate and checking whether it
+"held." Today that check is **backlog-count based**: a candidate fails if `receiveBacklog` or
+`publishBacklog` exceeds a message-count `limit` (absolute for AIMD, or `rate × rampMaxBacklogSeconds`
+clamped to `[rampMaxBacklogFloor, rampMaxBacklogCeiling]` for CHOP).
+
+An AKS re-validation on 2026-07-24 (matrix `finder-chop-revalidate.yaml`, digest-pinned image
+`sha256:4c43c65…`, `representative` preset, 1 topic / 100 partitions / 100-byte messages) exposed
+that this predicate is structurally wrong. Three loads on the **same cluster**:
+
+| Load | Config | Discovered rate | Sustained over 15 min? |
+|------|--------|-----------------|------------------------|
+| AIMD | fixed 1000-msg backlog limit | ~13,500 msg/s | yes (but conservative) |
+| chop-floor | `rampMaxBacklogSeconds: 0.1` | **2,734 msg/s** (clean confirm) | yes, trivially — far under capacity |
+| chop-ceiling | `rampMaxBacklogSeconds: 1.0` | **880,000 msg/s** (`nonMonotonic` → withheld) | **yes** — publish≈consume≈880k, backlog bounded (max 16,432, not growing), avg publish-delay 0.12 ms, e2e p99 326 ms |
+
+The true sustainable rate was **~880k msg/s**. AIMD under-reported it by ~65×, and `chop-floor` by
+~320×.
+
+**Root cause.** A healthy pipeline's natural in-flight backlog *scales with throughput* (~16k
+messages in flight at 880k msg/s; ~1k at 13k msg/s). So no fixed-ish message count is correct at
+once: a count strict enough to catch overload at low rates (≈1000) trips on the normal in-flight
+backlog of a fast pipeline and under-reports; a count loose enough for high rates is meaningless at
+low rates and lets bracket run away. Because the "clean" baseline moves with the rate, the predicate
+is also **non-monotone** in rate — which violates binary chop's key prerequisite and is why
+`nonMonotonic` fired on the *correct* 880k result (a false alarm that withheld the one good answer).
+
+## Goals
+
+- Make CHOP's verdict depend on **scale-free** signals so one threshold is correct at every rate and
+  message size — fixing both the under-report (low rates) and the runaway (high rates) with a single
+  mechanism, and restoring monotonicity so chop is valid and `nonMonotonic` stops false-firing.
+- Ship it as an **opt-in verdict mode**, leaving the current behavior (and PR #19's semantics) as the
+  default — consistent with how CHOP itself was added alongside AIMD.
+
+## Non-goals
+
+- Removing the backlog-count predicate or its knobs (kept for the default `BACKLOG` mode).
+- Adding a latency-based gate (achieved-rate + consumer-drain cover both failure modes; a latency
+  gate can be a later addition if wanted).
+- Changing the bracket / chop / confirmation-hold / reopen-on-failed-confirm / safety-cap /
+  `nonMonotonic` machinery — all of it is reused unchanged.
+- Fixing hold-length sensitivity (see Risks) — orthogonal to this change.
+
+## Design
+
+### Config surface (`Workload`)
+
+- **`rampVerdict`** — new enum `RampVerdict { BACKLOG, THROUGHPUT }`, default `BACKLOG`. Selects how
+  a hold's clean/exceeded verdict is decided. Applies only to CHOP (`producerRate: 0`,
+  `rampAlgorithm: CHOP`).
+- **`rampMinThroughputRatio`** — new `Double`, default `0.95`. Used only when
+  `rampVerdict: THROUGHPUT`. The minimum fraction of target throughput (and of consumer drain) a
+  candidate must achieve to count as clean.
+- Existing `rampMaxBacklogSeconds`, `rampMaxBacklogFloor`, `rampMaxBacklogCeiling`,
+  `rampPublishBacklogLimit`, `rampReceiveBacklogLimit` — unchanged, used only under
+  `rampVerdict: BACKLOG`.
+
+### The predicate
+
+Under `THROUGHPUT`, a candidate is judged **at the end of each hold** (bracket hold or chop hold),
+over that hold's window `[t0, t1]` at the fixed candidate `rate`:
+
+```
+expected  = rate × (t1 − t0)
+published = totalPublished(t1) − totalPublished(t0)
+received  = totalReceived(t1)  − totalReceived(t0)
+
+producerKeepsUp = published ≥ rampMinThroughputRatio × expected
+consumerKeepsUp = received  ≥ rampMinThroughputRatio × published
+
+clean  ⇔  producerKeepsUp AND consumerKeepsUp     (otherwise: exceeded)
+```
+
+- Both gates are **fractions**, so the single `rampMinThroughputRatio` is correct at every rate and
+  message size — no floor/ceiling/count tuning.
+- `consumerKeepsUp` compares to *published*, not *expected*: a lagging consumer is not
+  double-penalised for messages the producer never sent (producer shortfall is already caught by
+  `producerKeepsUp`). Over a full hold, a consumer that keeps up yields `received ≈ published`.
+- Validation against the AKS data: 880k → `published/expected ≈ 1.00`, `received/published ≈ 1.00` →
+  **clean** (correct); a 1.8M candidate that only achieved ~1.3–1.5M → `≈ 0.72–0.83` → **exceeded**
+  (correctly rejected); low rates where producer and consumer both keep up → clean, so discovery
+  **keeps climbing** instead of sticking at 2,734.
+
+### Integration with the existing finder
+
+- The **only** change to the state machine is the function that turns a completed hold into a
+  `clean`/`exceeded` boolean. `RampRateFinder` gains a hold-start snapshot of the cumulative
+  counters (`totalPublished`, `totalReceived`) so it can compute the two ratios when the hold
+  completes; a small strategy branch selects `BACKLOG` (existing per-poll count check) vs
+  `THROUGHPUT` (this ratio check).
+- Bracket doubling/halving, chop bisection, confirmation holds, reopen-on-failed-confirm, the safety
+  cap, and `nonMonotonic` recording are **reused verbatim** — they consume the boolean and are
+  agnostic to how it was produced.
+- **No new `Worker` API.** The finder already receives cumulative `totalPublished`/`totalReceived`
+  each poll, so this is distributed-worker compatible unchanged.
+
+### Behavioral difference: no per-poll fast-fail under `THROUGHPUT`
+
+The ratios need the whole hold window, so a `THROUGHPUT` candidate is judged only at hold
+completion — there is no mid-hold fast-fail. (`BACKLOG` keeps its current per-poll fast-fail on a
+count breach.) Consequence: discovery is slower under `THROUGHPUT` (every candidate, including
+doomed high overshoots during bracket, runs its full hold). This is an accepted trade for a
+correct, scale-free verdict.
+
+## Back-compat & migration
+
+- Default `rampVerdict: BACKLOG` ⇒ **zero behavior change**; existing workloads and PR #19 semantics
+  are untouched.
+- `THROUGHPUT` is purely opt-in via the new field. Existing example workload YAMLs are unaffected.
+- `rampVerification` output shape is unchanged. Under `THROUGHPUT`, `nonMonotonic` is expected to be
+  `false` far more often (monotone predicate), so the object will be present (and the rate reported)
+  on runs that the count predicate would have withheld.
+
+## Testing plan
+
+- **Unit (`RampRateFinderTest`)** — extend the fake broker to also model consumer drain (a
+  sustained consume capacity), then add `THROUGHPUT` cases:
+  1. climbs past the rate where a 1000-message count limit would stick (the under-report fix);
+  2. rejects an oversubscribed rate (`achievedFraction` below the ratio);
+  3. fails when the producer keeps up but the consumer lags (`consumerKeepsUp` false);
+  4. `nonMonotonic` stays `false` across a clean monotone climb it would previously have tripped.
+- **Integration (`ChopRateFinderKafkaIT`, `-Pintegration-tests`)** — add a `THROUGHPUT` variant that
+  asserts it converges to a sustainable rate **≥** the `BACKLOG` path on the same broker (relative
+  assertion, machine-independent), reusing the existing sustainability check (bounded publish-delay).
+- **Docs (`RATE_FINDING.md`)** — document both verdict modes and the predicate; record the AKS
+  finding (880k sustained vs 2,734 under-report vs 13.5k AIMD) as the motivation; note the
+  hold-length guideline applies to both modes.
+
+## Risks & open questions
+
+- **Hold-length sensitivity is not solved by this change.** A hold shorter than the broker's
+  burst-absorption time can still see `published ≈ expected` during a burst and pass an unsustainable
+  rate. This is orthogonal (it affects `BACKLOG` too) and is covered by a separate hold-length
+  guideline. `THROUGHPUT` fixes the *scale/count* problem, not the *hold-duration* problem.
+- **Client-side rate-limiter bottleneck.** If OMB's own rate limiter cannot schedule the target
+  rate, `producerKeepsUp` fails for a non-broker reason. That is still the honest benchmark answer
+  ("this setup can't sustain this rate"); if disambiguation is ever needed, publish-delay separates
+  producer-side stalls from broker saturation.
+- **Threshold default (0.95).** A fraction, so one value spans all rates, but the exact number is a
+  judgment call; 0.95 gives ~5% slack for jitter over a 30–60 s hold. Configurable via
+  `rampMinThroughputRatio`.
+- **Sustainability horizon.** "Sustainable" still means "over the measurement/hold window"; disk
+  fill, GC, and compaction act on longer horizons. Not made worse by this change.
+
+## References
+
+- `benchmark-framework/src/main/java/io/openmessaging/benchmark/RampRateFinder.java` — verdict at
+  `poll()` (current backlog-count check ~L166–187); bracket/chop machinery ~L194–293.
+- `benchmark-framework/RATE_FINDING.md` — algorithm docs and the two "Trial finding" incidents.
+- AKS run 30103329337 (`conduktor/benchmarks`) — the re-validation that produced the data above.

--- a/etc/findbugsExclude.xml
+++ b/etc/findbugsExclude.xml
@@ -19,6 +19,10 @@
     <Bug pattern="UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD" />
   </Match>
   <Match>
+    <Class name="io.openmessaging.benchmark.RampVerification" />
+    <Bug pattern="URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD" />
+  </Match>
+  <Match>
     <Class name="io.openmessaging.benchmark.driver.jms.JMSBenchmarkConsumer" />
     <Bug pattern="EI_EXPOSE_REP2" />
   </Match>

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,9 @@
         <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
         <maven.enforcer.plugin.version>3.1.0</maven.enforcer.plugin.version>
         <maven.surefire.plugin.version>3.0.0-M7</maven.surefire.plugin.version>
+        <!-- Integration tests (failsafe *IT) are skipped by default so PR CI stays fast and
+             Docker-free; enable with the integration-tests profile or -DskipITs=false. -->
+        <skipITs>true</skipITs>
         <spotbugs.plugin.version>4.7.2.0</spotbugs.plugin.version>
         <spotless.plugin.version>2.25.0</spotless.plugin.version>
     </properties>
@@ -347,6 +350,9 @@
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>${maven.surefire.plugin.version}</version>
+                <configuration>
+                    <skipITs>${skipITs}</skipITs>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>
@@ -491,6 +497,14 @@
                     </plugins>
                 </pluginManagement>
             </build>
+        </profile>
+        <profile>
+            <!-- Opt in to the Docker-backed integration tests (failsafe *IT), e.g.
+                 mvn verify -Pintegration-tests. Requires a running Docker daemon. -->
+            <id>integration-tests</id>
+            <properties>
+                <skipITs>false</skipITs>
+            </properties>
         </profile>
     </profiles>
 </project>

--- a/workloads/max-rate-chop-1-topic-100-partitions-100b.yaml
+++ b/workloads/max-rate-chop-1-topic-100-partitions-100b.yaml
@@ -1,0 +1,41 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Max rate (CHOP) 1 producer on 1 topic / 100 partition / 100 bytes
+
+topics: 1
+partitionsPerTopic: 100
+messageSize: 100
+payloadFile: "payload/payload-100b.data"
+subscriptionsPerTopic: 1
+consumerPerSubscription: 1
+producersPerTopic: 1
+
+# Discover max-sustainable rate using bracket + binary-chop + hold-and-verify instead of the
+# default continuous AIMD controller. Unlike AIMD, this converges to a fixed rate and stops
+# adjusting well before testDurationMinutes elapses, so the measurement window runs at an
+# already-verified rate.
+producerRate: 0
+rampAlgorithm: CHOP
+
+rampStartRate: 5000
+rampPublishBacklogLimit: 1000
+rampReceiveBacklogLimit: 1000
+rampBracketPeriodSeconds: 3
+rampHoldSeconds: 30
+rampConvergenceTolerance: 0.05
+rampMaxDiscoveryMinutes: 10
+
+consumerBacklogSizeGB: 0
+testDurationMinutes: 5

--- a/workloads/max-rate-chop-1-topic-100-partitions-100b.yaml
+++ b/workloads/max-rate-chop-1-topic-100-partitions-100b.yaml
@@ -33,6 +33,8 @@ rampStartRate: 5000
 rampPublishBacklogLimit: 1000
 rampReceiveBacklogLimit: 1000
 rampBracketPeriodSeconds: 3
+rampSettleSeconds: 30
+rampBracketHoldSeconds: 30
 rampHoldSeconds: 30
 rampConvergenceTolerance: 0.05
 rampMaxDiscoveryMinutes: 10


### PR DESCRIPTION
## Summary
- The existing max-sustainable-rate probe (`producerRate: 0`) uses a continuous AIMD controller that never verifies a candidate rate before accepting it and never stops adjusting — so the "discovered" rate isn't always reproducible when fixed and re-run later.
- Adds a second, **opt-in** algorithm (`rampAlgorithm: CHOP`) that brackets the knee via exponential doubling, then binary-chops within the bracket, holding and verifying each candidate rate for a configurable window before accepting it. A lightweight non-monotonicity check flags results that may not reproduce cleanly.
- The existing AIMD algorithm and its tests are **untouched** and remain the default (`rampAlgorithm: AIMD`), so every existing workload YAML keeps its current behavior unless it explicitly opts in.

## New workload fields (all optional, only apply when `producerRate: 0`)
- `rampAlgorithm` (`AIMD` default | `CHOP`)
- `rampStartRate`, `rampPublishBacklogLimit`, `rampReceiveBacklogLimit` — shared by both algorithms
- `rampBracketPeriodSeconds`, `rampHoldSeconds`, `rampConvergenceTolerance`, `rampMaxDiscoveryMinutes` — CHOP only

## Test plan
- [x] `RateControllerTest` (existing AIMD tests) pass unchanged
- [x] New `RampRateFinderTest` covers bracket→chop transition, convergence within tolerance, early-exit on failed hold, non-monotonicity detection, and the safety-cap
- [x] Full `mvn install` (checkstyle + spotbugs + tests) passes for `benchmark-framework` and the whole multi-module build
- [x] Verified end-to-end against a local single-broker Kafka cluster: discovery converged to a rate, correctly flagged non-monotonic backlog behavior, and that flag was a true positive (the measurement window at that rate built up real backlog/latency) — see `workloads/max-rate-chop-1-topic-100-partitions-100b.yaml` for a runnable example

🤖 Generated with [Claude Code](https://claude.com/claude-code)