### PR TITLE
Add CI Docker image build/push on PR and main

### DIFF
--- a/.github/workflows/pr-build-and-test.yml
+++ b/.github/workflows/pr-build-and-test.yml
@@ -10,7 +10,7 @@ on:
 
 permissions:
   contents: read
-  id-token: write
+  packages: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -75,17 +75,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Docker multi registries login
-        uses: conduktor/conduktor-actions/docker-multi-registries-login@main
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker image metadata
         id: docker_meta
-        uses: conduktor/conduktor-actions/docker-multi-registries-metadata@main
+        uses: docker/metadata-action@v5
         with:
-          tag-harbor: true
-          tag-ghcr: false
-          namespace: conduktor
-          image-names: openmessaging-benchmark
+          images: ghcr.io/conduktor/openmessaging-benchmark
           tags: |
             type=ref,event=pr
             type=raw,value=conduktor-gateway,enable=${{ github.event_name == 'push' }}

--- a/.github/workflows/pr-build-and-test.yml
+++ b/.github/workflows/pr-build-and-test.yml
@@ -72,6 +72,11 @@ jobs:
       - name: Resolve benchmark tarball
         run: echo "BENCHMARK_TARBALL=$(ls package/target/openmessaging-benchmark-*-bin.tar.gz)" >> "$GITHUB_ENV"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -103,7 +108,7 @@ jobs:
           context: .
           file: docker/Dockerfile
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           build-args: |
             BENCHMARK_TARBALL=${{ env.BENCHMARK_TARBALL }}
           tags: ${{ steps.docker_meta.outputs.tags }}

--- a/.github/workflows/pr-build-and-test.yml
+++ b/.github/workflows/pr-build-and-test.yml
@@ -3,10 +3,14 @@ name: Build and test
 on:
   pull_request:
     branches:
-      - master
+      - conduktor-gateway
   push:
     branches:
-      - master
+      - conduktor-gateway
+
+permissions:
+  contents: read
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -30,6 +34,13 @@ jobs:
       - name: Build and Verify
         run: mvn --no-transfer-progress --batch-mode verify
 
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: maven-target
+          path: "**/target/"
+          retention-days: 1
+
       - name: package surefire test results
         if: failure()
         run: |
@@ -43,3 +54,58 @@ jobs:
         with:
           name: test-results
           path: test-results.zip
+
+  publish-image:
+    needs: build
+    if: github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: maven-target
+          path: .
+
+      - name: Resolve benchmark tarball
+        run: echo "BENCHMARK_TARBALL=$(ls package/target/openmessaging-benchmark-*-bin.tar.gz)" >> "$GITHUB_ENV"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Docker multi registries login
+        uses: conduktor/conduktor-actions/docker-multi-registries-login@main
+
+      - name: Docker image metadata
+        id: docker_meta
+        uses: conduktor/conduktor-actions/docker-multi-registries-metadata@main
+        with:
+          tag-harbor: true
+          tag-ghcr: false
+          namespace: conduktor
+          image-names: openmessaging-benchmark
+          tags: |
+            type=ref,event=pr
+            type=raw,value=conduktor-gateway,enable=${{ github.event_name == 'push' }}
+            type=raw,value=conduktor-gateway-${{ github.sha }},enable=${{ github.event_name == 'push' }}
+          labels: |
+            org.opencontainers.image.title=OpenMessaging Benchmark
+            org.opencontainers.image.description=Benchmark suite used to load-test Conduktor Gateway
+            org.opencontainers.image.authors=Conduktor <support@conduktor.io>
+            org.opencontainers.image.vendor=Conduktor.io
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: true
+          platforms: linux/amd64
+          build-args: |
+            BENCHMARK_TARBALL=${{ env.BENCHMARK_TARBALL }}
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ github.event_name == 'pull_request' && 'pr' || 'main' }}
+          cache-to: type=gha,scope=${{ github.event_name == 'pull_request' && 'pr' || 'main' }},mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  release-image:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Build and Verify
+        run: mvn --no-transfer-progress --batch-mode verify
+
+      - name: Resolve benchmark tarball
+        run: echo "BENCHMARK_TARBALL=$(ls package/target/openmessaging-benchmark-*-bin.tar.gz)" >> "$GITHUB_ENV"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker image metadata
+        id: docker_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/conduktor/openmessaging-benchmark
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+          labels: |
+            org.opencontainers.image.title=OpenMessaging Benchmark
+            org.opencontainers.image.description=Benchmark suite used to load-test Conduktor Gateway
+            org.opencontainers.image.authors=Conduktor <support@conduktor.io>
+            org.opencontainers.image.vendor=Conduktor.io
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            BENCHMARK_TARBALL=${{ env.BENCHMARK_TARBALL }}
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          cache-from: type=gha,scope=release
+          cache-to: type=gha,scope=release,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,21 @@
 name: Release
+run-name: "Release ${{ inputs.version || github.ref_name }}${{ inputs.dry_run && ' (dry run)' || '' }}"
 
 on:
   push:
     tags:
       - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        type: string
+        description: Version to simulate, e.g. 1.2.3 or 1.2.3-dryrun
+      dry_run:
+        required: false
+        type: boolean
+        default: true
+        description: Build the image but skip pushing it to GHCR
 
 permissions:
   contents: read
@@ -52,9 +64,9 @@ jobs:
         with:
           images: ghcr.io/conduktor/openmessaging-benchmark
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=semver,pattern={{version}},value=${{ inputs.version || github.ref_name }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version || github.ref_name }}
+            type=semver,pattern={{major}},value=${{ inputs.version || github.ref_name }}
           labels: |
             org.opencontainers.image.title=OpenMessaging Benchmark
             org.opencontainers.image.description=Benchmark suite used to load-test Conduktor Gateway
@@ -66,7 +78,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
-          push: true
+          push: ${{ github.event_name == 'push' || inputs.dry_run == false }}
           platforms: linux/amd64,linux/arm64
           build-args: |
             BENCHMARK_TARBALL=${{ env.BENCHMARK_TARBALL }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,17 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 services:
   zookeeper:
     image: "confluentinc/cp-zookeeper:latest"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@
 # limitations under the License.
 #
 
-FROM openjdk:8-jdk
+FROM eclipse-temurin:8-jdk
 
 ARG BENCHMARK_TARBALL
 

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -19,7 +19,7 @@ WORKDIR /benchmark
 RUN mvn install
 
 # Create the benchmark image
-FROM openjdk:8-jdk
+FROM eclipse-temurin:8-jdk
 COPY --from=build /benchmark/package/target/openmessaging-benchmark-*-SNAPSHOT-bin.tar.gz /
 RUN mkdir /benchmark && tar -xzf openmessaging-benchmark-*-SNAPSHOT-bin.tar.gz -C /benchmark --strip=1
 RUN rm /openmessaging-benchmark-*-SNAPSHOT-bin.tar.gz

--- a/driver-gateway/deploy/ssd-deployment/requirements.yml
+++ b/driver-gateway/deploy/ssd-deployment/requirements.yml
@@ -1,3 +1,17 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 ansible==9.7.0
 ansible-core==2.16.8
 ---


### PR DESCRIPTION
## Summary
- Add a `publish-image` job to the existing PR/main CI workflow that builds and pushes `ghcr.io/conduktor/openmessaging-benchmark`, multi-arch (`linux/amd64` + `linux/arm64`):
  - `pr-<N>` tag on every PR
  - `conduktor-gateway` (floating) + `conduktor-gateway-<sha>` (immutable) on push to the default branch
- Uses the standard `docker/login-action` + `docker/metadata-action` with the built-in `GITHUB_TOKEN` (no extra secrets) — this repo is public, and Conduktor's internal Harbor login (`conduktor/conduktor-actions`, an internal-visibility repo, + AWS OIDC) isn't usable from public-repo workflows, per platform team feedback.
- Fix the workflow's stale `master` branch trigger to this repo's actual default branch, `conduktor-gateway`.
- Add a new `release.yml` workflow: pushing a `vX.Y.Z` tag builds and publishes `X.Y.Z` / `X.Y` / `X` semver tags, also multi-arch. Includes a `workflow_dispatch` input (`version`, `dry_run`) so the whole pipeline can be validated without pushing a real tag or a real image — `dry_run: true` (the default) builds but skips the GHCR push.
- Fix two pre-existing bugs that were blocking any of this from actually running:
  - `docker-compose.yml` and `driver-gateway/deploy/ssd-deployment/requirements.yml` were missing the Apache license header, failing the `license-maven-plugin` check in the `build` job.
  - `docker/Dockerfile` and `docker/Dockerfile.build` both `FROM openjdk:8-jdk`, an image Docker Hub removed years ago — switched to `eclipse-temurin:8-jdk`.

## Test plan
- [x] `mvn com.mycila:license-maven-plugin:4.1:check` passes across the full reactor
- [x] `build` job passes in CI
- [x] `publish-image` job passes in CI; confirmed `ghcr.io/conduktor/openmessaging-benchmark:pr-20` is a multi-arch manifest (amd64 + arm64) via `docker manifest inspect`
- [ ] `release.yml`'s `workflow_dispatch` dry run — blocked until this merges, since GitHub only allows dispatching a workflow that already exists on the default branch; plan to validate right after merge
- [ ] After merge: confirm push-triggered run publishes `conduktor-gateway` and `conduktor-gateway-<sha>` tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)