### PR TITLE
feat(ci): lock master to upstream-only fast-forward sync

### DIFF
--- a/.github/workflows/sync-upstream-master.yml
+++ b/.github/workflows/sync-upstream-master.yml
@@ -1,0 +1,31 @@
+name: Sync master from upstream
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # weekly; upstream moves ~5 commits/18mo, no need for daily
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: master
+          fetch-depth: 0
+          token: ${{ secrets.CONDUKTORBOT_REPO_WRITE }}
+
+      - name: Add upstream remote
+        run: git remote add upstream https://github.com/openmessaging/benchmark.git
+
+      - name: Fetch upstream master
+        run: git fetch upstream master
+
+      - name: Refuse anything but a clean fast-forward
+        run: git merge-base --is-ancestor origin/master upstream/master
+
+      - name: Push upstream master to our master
+        run: git push origin upstream/master:refs/heads/master

--- a/.github/workflows/verify-upstream-ancestor.yml
+++ b/.github/workflows/verify-upstream-ancestor.yml
@@ -1,0 +1,27 @@
+name: Verify upstream ancestor
+
+on:
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  verify-upstream-ancestor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Add upstream remote
+        run: git remote add upstream https://github.com/openmessaging/benchmark.git
+
+      - name: Fetch upstream master
+        run: git fetch upstream master
+
+      - name: Refuse anything that isn't upstream's own history
+        run: git merge-base --is-ancestor HEAD upstream/master


### PR DESCRIPTION
## What

- \`sync-upstream-master.yml\` — scheduled (weekly) + manual-dispatch job where ConduktorBot fetches \`openmessaging/benchmark:master\` and fast-forwards our \`master\` to it. Refuses to push unless \`origin/master\` is a strict ancestor of upstream's tip (never rewrites, never accepts a divergent push).
- \`verify-upstream-ancestor.yml\` — required check for the (should-be-rare) case someone opens a PR straight against \`master\`: fails unless the PR head is reachable from upstream's tip.

## Why

\`master\` is meant to be a pure mirror of upstream — the common base \`conduktor-gateway\` and \`conduktor\` (the engine-fix branch) both diverge from. Today any repo/org admin can fast-forward-push arbitrary content to it directly, bypassing review entirely (verified by testing it). This PR is paired with a GitHub-side ruleset change (not a file — tracked separately via \`gh api\`) that:
- Splits \`master\` out of the shared "Main branch" ruleset into its own ruleset
- Makes ConduktorBot the *only* bypass actor (no admin bypass) so all humans must go through a PR
- Requires the \`verify-upstream-ancestor\` check to pass before any such PR can merge

## Validation

- [ ] After merge, dispatch \`sync-upstream-master.yml\` manually and confirm a green no-op run (master already equals upstream tip)
- [ ] Confirm a direct fast-forward push to \`master\` as a human is now rejected