### PR TITLE
Merge upstream (via master) into conduktor-gateway

### DIFF
--- a/.github/workflows/pr-build-and-test.yml
+++ b/.github/workflows/pr-build-and-test.yml
@@ -37,7 +37,7 @@ jobs:
           mkdir test-results
           find . -type d -name "*surefire*" -exec cp --parents -R {} test-results/ \;
           zip -r test-results.zip test-results
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         name: upload test-results
         if: failure()
         with:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This repository houses user-friendly, cloud-ready benchmarking suites for the fo
 * [Pravega](https://pravega.io/)
 * [RabbitMQ](https://www.rabbitmq.com/)
 * [Redis](https://redis.com/)
+* [MQTT](https://mqtt.org/)
 
 > More details could be found at the [official documentation](http://openmessaging.cloud/docs/benchmarks/).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# OpenMessaging Benchmark Framework
+# Fork of the OpenMessaging Benchmark Framework that uses sapmachine 17 docker image
+
+This fork is used to update the outdated offical docker hub image openmessaging/openmessaging-benchmark with sapmachine:17.
+Find more in [./docker/README.md](./docker/README.md).
 
 [![Build](https://github.com/openmessaging/benchmark/actions/workflows/pr-build-and-test.yml/badge.svg)](https://github.com/openmessaging/benchmark/actions/workflows/pr-build-and-test.yml)
 [![License](https://img.shields.io/badge/license-Apache%202-4EB1BA.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
@@ -27,7 +30,7 @@ This repository houses user-friendly, cloud-ready benchmarking suites for the fo
 
 Requirements:
 
-* JDK 8
+* JDK 17
 * Maven 3.8.6+
 
 Common build actions:

--- a/benchmark-framework/pom.xml
+++ b/benchmark-framework/pom.xml
@@ -107,6 +107,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>driver-rocketmq5</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
         </dependency>

--- a/benchmark-framework/pom.xml
+++ b/benchmark-framework/pom.xml
@@ -68,6 +68,11 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>driver-mqtt5</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>driver-nats</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
@@ -15,6 +15,7 @@ package io.openmessaging.benchmark;
 
 
 import io.openmessaging.benchmark.utils.distributor.KeyDistributorType;
+import java.util.Map;
 
 public class Workload {
     public String name;
@@ -28,6 +29,23 @@ public class Workload {
     public KeyDistributorType keyDistributor = KeyDistributorType.NO_KEY;
 
     public int messageSize;
+
+    /**
+     * Message size distribution for variable-sized payloads.
+     * Keys are size ranges (e.g., "0-256", "256-1024", "1KB-4KB"),
+     * values are relative weights.
+     * Mutually exclusive with messageSize - if set, messageSize is ignored.
+     */
+    public Map<String, Integer> messageSizeDistribution;
+
+    /**
+     * Returns true if this workload uses a size distribution instead of fixed size.
+     *
+     * @return true if messageSizeDistribution is configured, false otherwise
+     */
+    public boolean usesDistribution() {
+        return messageSizeDistribution != null && !messageSizeDistribution.isEmpty();
+    }
 
     public boolean useRandomizedPayloads;
     public double randomBytesRatio;

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
@@ -31,10 +31,9 @@ public class Workload {
     public int messageSize;
 
     /**
-     * Message size distribution for variable-sized payloads.
-     * Keys are size ranges (e.g., "0-256", "256-1024", "1KB-4KB"),
-     * values are relative weights.
-     * Mutually exclusive with messageSize - if set, messageSize is ignored.
+     * Message size distribution for variable-sized payloads. Keys are size ranges (e.g., "0-256",
+     * "256-1024", "1KB-4KB"), values are relative weights. Mutually exclusive with messageSize - if
+     * set, messageSize is ignored.
      */
     public Map<String, Integer> messageSizeDistribution;
 

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
@@ -20,6 +20,7 @@ import io.openmessaging.benchmark.utils.PaddingDecimalFormat;
 import io.openmessaging.benchmark.utils.RandomGenerator;
 import io.openmessaging.benchmark.utils.Timer;
 import io.openmessaging.benchmark.utils.payload.FilePayloadReader;
+import io.openmessaging.benchmark.utils.payload.MessageSizeDistribution;
 import io.openmessaging.benchmark.utils.payload.PayloadReader;
 import io.openmessaging.benchmark.worker.Worker;
 import io.openmessaging.benchmark.worker.commands.ConsumerAssignment;
@@ -95,16 +96,39 @@ public class WorkloadGenerator implements AutoCloseable {
                     });
         }
 
-        final PayloadReader payloadReader = new FilePayloadReader(workload.messageSize);
-
         ProducerWorkAssignment producerWorkAssignment = new ProducerWorkAssignment();
         producerWorkAssignment.keyDistributorType = workload.keyDistributor;
         producerWorkAssignment.publishRate = targetPublishRate;
         producerWorkAssignment.payloadData = new ArrayList<>();
 
-        if (workload.useRandomizedPayloads) {
-            // create messages that are part random and part zeros
-            // better for testing effects of compression
+        if (workload.usesDistribution()) {
+            // Distribution mode: create one payload per bucket with weighted selection at runtime
+            MessageSizeDistribution dist = new MessageSizeDistribution(workload.messageSizeDistribution);
+            List<Integer> sizes = dist.getBucketMaxSizes();
+            Random r = new Random();
+
+            log.info(
+                    "Creating {} payloads for size distribution (max sizes: {}, weighted avg: {} bytes)",
+                    sizes.size(),
+                    sizes,
+                    dist.getAvgSize());
+
+            for (int size : sizes) {
+                byte[] payload = new byte[size];
+                if (workload.useRandomizedPayloads) {
+                    int randomBytes = (int) (size * workload.randomBytesRatio);
+                    r.nextBytes(payload);
+                    // Zero out non-random portion for compressibility testing
+                    for (int j = randomBytes; j < size; j++) {
+                        payload[j] = 0;
+                    }
+                }
+                producerWorkAssignment.payloadData.add(payload);
+            }
+            producerWorkAssignment.payloadWeights = dist.getWeights();
+
+        } else if (workload.useRandomizedPayloads) {
+            // Existing fixed-size randomized payload logic
             Random r = new Random();
             int randomBytes = (int) (workload.messageSize * workload.randomBytesRatio);
             int zerodBytes = workload.messageSize - randomBytes;
@@ -116,6 +140,8 @@ public class WorkloadGenerator implements AutoCloseable {
                 producerWorkAssignment.payloadData.add(combined);
             }
         } else {
+            // Existing file-based payload logic
+            final PayloadReader payloadReader = new FilePayloadReader(workload.messageSize);
             producerWorkAssignment.payloadData.add(payloadReader.load(workload.payloadFile));
         }
 
@@ -275,13 +301,19 @@ public class WorkloadGenerator implements AutoCloseable {
 
         this.needToWaitForBacklogDraining = true;
 
+        // Use average size when distribution is configured, otherwise fixed messageSize
+        int effectiveMessageSize =
+                workload.usesDistribution()
+                        ? new MessageSizeDistribution(workload.messageSizeDistribution).getAvgSize()
+                        : workload.messageSize;
+
         long requestedBacklogSize = workload.consumerBacklogSizeGB * 1024 * 1024 * 1024;
 
         while (true) {
             CountersStats stats = worker.getCountersStats();
             long currentBacklogSize =
                     (workload.subscriptionsPerTopic * stats.messagesSent - stats.messagesReceived)
-                            * workload.messageSize;
+                            * effectiveMessageSize;
 
             if (currentBacklogSize >= requestedBacklogSize) {
                 break;
@@ -300,7 +332,7 @@ public class WorkloadGenerator implements AutoCloseable {
 
         worker.resumeConsumers();
 
-        long backlogMessageCapacity = requestedBacklogSize / workload.messageSize;
+        long backlogMessageCapacity = requestedBacklogSize / effectiveMessageSize;
         long backlogEmptyLevel = (long) ((1.0 - workload.backlogDrainRatio) * backlogMessageCapacity);
         final long minBacklog = Math.max(1000L, backlogEmptyLevel);
 
@@ -343,7 +375,11 @@ public class WorkloadGenerator implements AutoCloseable {
         result.driver = driverName;
         result.topics = workload.topics;
         result.partitions = workload.partitionsPerTopic;
-        result.messageSize = workload.messageSize;
+        // Use average size when distribution is configured
+        result.messageSize =
+                workload.usesDistribution()
+                        ? new MessageSizeDistribution(workload.messageSizeDistribution).getAvgSize()
+                        : workload.messageSize;
         result.producersPerTopic = workload.producersPerTopic;
         result.consumersPerTopic = workload.consumerPerSubscription;
 

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/payload/MessageSizeDistribution.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/payload/MessageSizeDistribution.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openmessaging.benchmark.utils.payload;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Parses and represents a message size distribution from workload config.
+ * Creates one payload size per bucket and provides weights for runtime selection.
+ *
+ * <p>Example configuration:
+ * <pre>
+ * messageSizeDistribution:
+ *   "0-256": 234
+ *   "256-1024": 456
+ *   "1024-4096": 678
+ * </pre>
+ */
+public class MessageSizeDistribution {
+
+    private final List<Bucket> buckets;
+    private final int totalWeight;
+
+    /**
+     * Represents a single size bucket with min/max range and weight.
+     */
+    public static class Bucket {
+        public final int minSize;
+        public final int maxSize;
+        public final int weight;
+
+        Bucket(int minSize, int maxSize, int weight) {
+            this.minSize = minSize;
+            this.maxSize = maxSize;
+            this.weight = weight;
+        }
+
+        /**
+         * Returns midpoint of range as the representative size for this bucket.
+         *
+         * @return the representative size (midpoint of min and max)
+         */
+        public int getRepresentativeSize() {
+            return (minSize + maxSize) / 2;
+        }
+    }
+
+    public MessageSizeDistribution(Map<String, Integer> config) {
+        if (config == null || config.isEmpty()) {
+            throw new IllegalArgumentException("Distribution config cannot be null or empty");
+        }
+
+        List<Bucket> parsed = new ArrayList<>();
+        int total = 0;
+
+        for (Map.Entry<String, Integer> e : config.entrySet()) {
+            int[] range = parseRange(e.getKey());
+            int weight = e.getValue();
+            if (weight < 0) {
+                throw new IllegalArgumentException("Weight cannot be negative: " + weight);
+            }
+            parsed.add(new Bucket(range[0], range[1], weight));
+            total += weight;
+        }
+
+        this.buckets = parsed;
+        this.totalWeight = total;
+
+        if (totalWeight <= 0) {
+            throw new IllegalArgumentException("Distribution weights must sum to a positive value");
+        }
+    }
+
+    private int[] parseRange(String range) {
+        if (range == null || range.isEmpty()) {
+            throw new IllegalArgumentException("Range cannot be null or empty");
+        }
+
+        // Find the last hyphen that separates min and max (to handle negative numbers if any)
+        int lastHyphen = range.lastIndexOf('-');
+        if (lastHyphen <= 0) {
+            throw new IllegalArgumentException("Invalid range format (expected 'min-max'): " + range);
+        }
+
+        String minPart = range.substring(0, lastHyphen);
+        String maxPart = range.substring(lastHyphen + 1);
+
+        int minSize = parseSize(minPart);
+        int maxSize = parseSize(maxPart);
+
+        if (minSize < 0) {
+            throw new IllegalArgumentException("Min size cannot be negative: " + minSize);
+        }
+        if (maxSize < minSize) {
+            throw new IllegalArgumentException(
+                    "Max size must be >= min size: " + minSize + " > " + maxSize);
+        }
+
+        return new int[] {minSize, maxSize};
+    }
+
+    private int parseSize(String s) {
+        s = s.trim().toUpperCase();
+        int mult = 1;
+
+        if (s.endsWith("KB")) {
+            mult = 1024;
+            s = s.substring(0, s.length() - 2);
+        } else if (s.endsWith("MB")) {
+            mult = 1024 * 1024;
+            s = s.substring(0, s.length() - 2);
+        } else if (s.endsWith("B")) {
+            s = s.substring(0, s.length() - 1);
+        }
+
+        try {
+            return Integer.parseInt(s.trim()) * mult;
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid size format: " + s, e);
+        }
+    }
+
+    /**
+     * Returns list of representative sizes, one per bucket (for payload generation).
+     *
+     * @return list of representative sizes
+     */
+    public List<Integer> getBucketSizes() {
+        List<Integer> sizes = new ArrayList<>();
+        for (Bucket b : buckets) {
+            sizes.add(b.getRepresentativeSize());
+        }
+        return sizes;
+    }
+
+    /**
+     * Returns list of max sizes, one per bucket (for payload generation).
+     * Using max sizes ensures the system is tested with the largest messages in each bucket range.
+     *
+     * @return list of max sizes per bucket
+     */
+    public List<Integer> getBucketMaxSizes() {
+        List<Integer> sizes = new ArrayList<>();
+        for (Bucket b : buckets) {
+            sizes.add(b.maxSize);
+        }
+        return sizes;
+    }
+
+    /**
+     * Returns weights array matching bucket order (for runtime selection).
+     *
+     * @return array of weights for each bucket
+     */
+    public int[] getWeights() {
+        int[] weights = new int[buckets.size()];
+        for (int i = 0; i < buckets.size(); i++) {
+            weights[i] = buckets.get(i).weight;
+        }
+        return weights;
+    }
+
+    /**
+     * Returns cumulative weights array for O(log n) binary search selection.
+     *
+     * @return array of cumulative weights
+     */
+    public int[] getCumulativeWeights() {
+        int[] cumulative = new int[buckets.size()];
+        int sum = 0;
+        for (int i = 0; i < buckets.size(); i++) {
+            sum += buckets.get(i).weight;
+            cumulative[i] = sum;
+        }
+        return cumulative;
+    }
+
+    public int getTotalWeight() {
+        return totalWeight;
+    }
+
+    public int getMaxSize() {
+        return buckets.stream().mapToInt(b -> b.maxSize).max().orElse(0);
+    }
+
+    /**
+     * Returns weighted average size across all buckets.
+     *
+     * @return the weighted average size
+     */
+    public int getAvgSize() {
+        long sum = 0;
+        for (Bucket b : buckets) {
+            sum += (long) b.getRepresentativeSize() * b.weight;
+        }
+        return (int) (sum / totalWeight);
+    }
+
+    public int getBucketCount() {
+        return buckets.size();
+    }
+
+    public List<Bucket> getBuckets() {
+        return buckets;
+    }
+}
+

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/payload/MessageSizeDistribution.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/payload/MessageSizeDistribution.java
@@ -15,6 +15,7 @@ package io.openmessaging.benchmark.utils.payload;
 
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -214,6 +215,6 @@ public class MessageSizeDistribution {
     }
 
     public List<Bucket> getBuckets() {
-        return buckets;
+        return Collections.unmodifiableList(buckets);
     }
 }

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/payload/MessageSizeDistribution.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/payload/MessageSizeDistribution.java
@@ -13,15 +13,17 @@
  */
 package io.openmessaging.benchmark.utils.payload;
 
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 /**
- * Parses and represents a message size distribution from workload config.
- * Creates one payload size per bucket and provides weights for runtime selection.
+ * Parses and represents a message size distribution from workload config. Creates one payload size
+ * per bucket and provides weights for runtime selection.
  *
  * <p>Example configuration:
+ *
  * <pre>
  * messageSizeDistribution:
  *   "0-256": 234
@@ -34,9 +36,7 @@ public class MessageSizeDistribution {
     private final List<Bucket> buckets;
     private final int totalWeight;
 
-    /**
-     * Represents a single size bucket with min/max range and weight.
-     */
+    /** Represents a single size bucket with min/max range and weight. */
     public static class Bucket {
         public final int minSize;
         public final int maxSize;
@@ -147,8 +147,8 @@ public class MessageSizeDistribution {
     }
 
     /**
-     * Returns list of max sizes, one per bucket (for payload generation).
-     * Using max sizes ensures the system is tested with the largest messages in each bucket range.
+     * Returns list of max sizes, one per bucket (for payload generation). Using max sizes ensures the
+     * system is tested with the largest messages in each bucket range.
      *
      * @return list of max sizes per bucket
      */
@@ -217,4 +217,3 @@ public class MessageSizeDistribution {
         return buckets;
     }
 }
-

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/LocalWorker.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/LocalWorker.java
@@ -240,9 +240,7 @@ public class LocalWorker implements Worker, ConsumerCallback {
                                             idx = r.nextInt(payloadCount);
                                         }
                                         messageProducer.sendMessage(
-                                                p,
-                                                Optional.ofNullable(keyDistributor.next()),
-                                                payloads.get(idx));
+                                                p, Optional.ofNullable(keyDistributor.next()), payloads.get(idx));
                                     });
                         }
                     } catch (Throwable t) {

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/ProducerWorkAssignment.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/ProducerWorkAssignment.java
@@ -21,6 +21,13 @@ public class ProducerWorkAssignment {
 
     public List<byte[]> payloadData;
 
+    /**
+     * Weights for weighted payload selection. If null, uniform random selection is used.
+     * Each weight corresponds to the payload at the same index in payloadData.
+     * Used for message size distribution feature.
+     */
+    public int[] payloadWeights;
+
     public double publishRate;
 
     public KeyDistributorType keyDistributorType;
@@ -29,6 +36,7 @@ public class ProducerWorkAssignment {
         ProducerWorkAssignment copy = new ProducerWorkAssignment();
         copy.keyDistributorType = this.keyDistributorType;
         copy.payloadData = this.payloadData;
+        copy.payloadWeights = this.payloadWeights;
         copy.publishRate = publishRate;
         return copy;
     }

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/ProducerWorkAssignment.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/ProducerWorkAssignment.java
@@ -22,9 +22,9 @@ public class ProducerWorkAssignment {
     public List<byte[]> payloadData;
 
     /**
-     * Weights for weighted payload selection. If null, uniform random selection is used.
-     * Each weight corresponds to the payload at the same index in payloadData.
-     * Used for message size distribution feature.
+     * Weights for weighted payload selection. If null, uniform random selection is used. Each weight
+     * corresponds to the payload at the same index in payloadData. Used for message size distribution
+     * feature.
      */
     public int[] payloadWeights;
 

--- a/benchmark-framework/src/test/java/io/openmessaging/benchmark/utils/payload/MessageSizeDistributionTest.java
+++ b/benchmark-framework/src/test/java/io/openmessaging/benchmark/utils/payload/MessageSizeDistributionTest.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openmessaging.benchmark.utils.payload;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class MessageSizeDistributionTest {
+
+    @Test
+    void parsesBasicRanges() {
+        Map<String, Integer> config = new LinkedHashMap<>();
+        config.put("0-256", 100);
+        config.put("256-1024", 200);
+        config.put("1024-4096", 300);
+
+        MessageSizeDistribution dist = new MessageSizeDistribution(config);
+
+        assertThat(dist.getBucketCount()).isEqualTo(3);
+        assertThat(dist.getTotalWeight()).isEqualTo(600);
+    }
+
+    @Test
+    void parsesSizeSuffixes() {
+        Map<String, Integer> config = new LinkedHashMap<>();
+        config.put("0-1KB", 100);
+        config.put("1KB-1MB", 200);
+
+        MessageSizeDistribution dist = new MessageSizeDistribution(config);
+        List<Integer> sizes = dist.getBucketSizes();
+
+        // Midpoint of 0-1024 = 512
+        assertThat(sizes.get(0)).isEqualTo(512);
+        // Midpoint of 1024-1048576 = 524800
+        assertThat(sizes.get(1)).isEqualTo(524800);
+    }
+
+    @Test
+    void calculatesBucketSizesAsMidpoint() {
+        Map<String, Integer> config = new LinkedHashMap<>();
+        config.put("0-100", 1);
+        config.put("100-200", 1);
+        config.put("200-300", 1);
+
+        MessageSizeDistribution dist = new MessageSizeDistribution(config);
+        List<Integer> sizes = dist.getBucketSizes();
+
+        assertThat(sizes).containsExactly(50, 150, 250);
+    }
+
+    @Test
+    void calculatesWeightsArray() {
+        Map<String, Integer> config = new LinkedHashMap<>();
+        config.put("0-256", 234);
+        config.put("256-1024", 456);
+        config.put("1024-4096", 678);
+
+        MessageSizeDistribution dist = new MessageSizeDistribution(config);
+        int[] weights = dist.getWeights();
+
+        assertThat(weights).containsExactly(234, 456, 678);
+    }
+
+    @Test
+    void calculatesCumulativeWeights() {
+        Map<String, Integer> config = new LinkedHashMap<>();
+        config.put("0-256", 100);
+        config.put("256-1024", 200);
+        config.put("1024-4096", 300);
+
+        MessageSizeDistribution dist = new MessageSizeDistribution(config);
+        int[] cumulative = dist.getCumulativeWeights();
+
+        assertThat(cumulative).containsExactly(100, 300, 600);
+    }
+
+    @Test
+    void calculatesAverageSize() {
+        Map<String, Integer> config = new LinkedHashMap<>();
+        config.put("0-100", 1); // midpoint 50, weight 1
+        config.put("100-200", 1); // midpoint 150, weight 1
+
+        MessageSizeDistribution dist = new MessageSizeDistribution(config);
+
+        // (50 * 1 + 150 * 1) / 2 = 100
+        assertThat(dist.getAvgSize()).isEqualTo(100);
+    }
+
+    @Test
+    void calculatesMaxSize() {
+        Map<String, Integer> config = new LinkedHashMap<>();
+        config.put("0-256", 100);
+        config.put("256-1024", 200);
+        config.put("1024-5000", 300);
+
+        MessageSizeDistribution dist = new MessageSizeDistribution(config);
+
+        assertThat(dist.getMaxSize()).isEqualTo(5000);
+    }
+
+    @Test
+    void handlesProductionDistribution() {
+        // Real production distribution from the plan
+        Map<String, Integer> config = new LinkedHashMap<>();
+        config.put("0-256", 234);
+        config.put("256-1024", 456);
+        config.put("1024-4096", 678);
+        config.put("4096-16384", 312);
+        config.put("16384-65536", 98);
+        config.put("65536-262144", 45);
+        config.put("262144-1048576", 18);
+        config.put("1048576-5242880", 6);
+
+        MessageSizeDistribution dist = new MessageSizeDistribution(config);
+
+        assertThat(dist.getBucketCount()).isEqualTo(8);
+        assertThat(dist.getTotalWeight()).isEqualTo(1847);
+        assertThat(dist.getMaxSize()).isEqualTo(5242880); // 5MB
+        assertThat(dist.getBucketSizes()).hasSize(8);
+        assertThat(dist.getWeights()).hasSize(8);
+    }
+
+    @Test
+    void throwsOnEmptyConfig() {
+        assertThatThrownBy(() -> new MessageSizeDistribution(new HashMap<>()))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void throwsOnNullConfig() {
+        assertThatThrownBy(() -> new MessageSizeDistribution(null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void throwsOnInvalidRangeFormat() {
+        Map<String, Integer> config = new HashMap<>();
+        config.put("invalid", 100);
+
+        assertThatThrownBy(() -> new MessageSizeDistribution(config))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void throwsOnNegativeWeight() {
+        Map<String, Integer> config = new HashMap<>();
+        config.put("0-100", -1);
+
+        assertThatThrownBy(() -> new MessageSizeDistribution(config))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void throwsOnZeroTotalWeight() {
+        Map<String, Integer> config = new HashMap<>();
+        config.put("0-100", 0);
+        config.put("100-200", 0);
+
+        assertThatThrownBy(() -> new MessageSizeDistribution(config))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void throwsOnInvalidMinMax() {
+        Map<String, Integer> config = new HashMap<>();
+        config.put("200-100", 1); // max < min
+
+        assertThatThrownBy(() -> new MessageSizeDistribution(config))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void weightedSelectionProducesCorrectDistribution() {
+        Map<String, Integer> config = new LinkedHashMap<>();
+        config.put("0-100", 100); // 50% weight
+        config.put("100-200", 100); // 50% weight
+
+        MessageSizeDistribution dist = new MessageSizeDistribution(config);
+        int[] cumulative = dist.getCumulativeWeights();
+        int totalWeight = dist.getTotalWeight();
+
+        // Simulate weighted selection like LocalWorker does
+        int[] counts = new int[2];
+        int iterations = 100000;
+
+        for (int i = 0; i < iterations; i++) {
+            int target = i % totalWeight; // Deterministic for testing
+            int idx = Arrays.binarySearch(cumulative, target + 1);
+            if (idx < 0) {
+                idx = -idx - 1;
+            }
+            idx = Math.min(idx, 1);
+            counts[idx]++;
+        }
+
+        // Each bucket should get approximately 50% of selections
+        double ratio0 = (double) counts[0] / iterations;
+        double ratio1 = (double) counts[1] / iterations;
+
+        assertThat(ratio0).isBetween(0.49, 0.51);
+        assertThat(ratio1).isBetween(0.49, 0.51);
+    }
+}
+

--- a/benchmark-framework/src/test/java/io/openmessaging/benchmark/utils/payload/MessageSizeDistributionTest.java
+++ b/benchmark-framework/src/test/java/io/openmessaging/benchmark/utils/payload/MessageSizeDistributionTest.java
@@ -219,4 +219,3 @@ class MessageSizeDistributionTest {
         assertThat(ratio1).isBetween(0.49, 0.51);
     }
 }
-

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -27,4 +27,4 @@ fi
 JVM_MEM="${HEAP_OPTS} -XX:+UseG1GC"
 JVM_GC_LOG=" -XX:+PrintGCDetails -XX:+PrintGCApplicationStoppedTime  -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=64m  -Xloggc:/dev/shm/benchmark-client-gc_%p.log"
 
-java -server -cp $CLASSPATH $JVM_MEM io.openmessaging.benchmark.Benchmark $*
+java -server -cp $CLASSPATH $JVM_MEM io.openmessaging.benchmark.Benchmark "$@"

--- a/bin/benchmark-worker
+++ b/bin/benchmark-worker
@@ -26,5 +26,12 @@ fi
 
 JVM_MEM="${HEAP_OPTS} -XX:+UseG1GC"
 JVM_GC_LOG=" -XX:+PrintGCDetails -XX:+PrintGCApplicationStoppedTime  -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=64m  -Xloggc:/dev/shm/benchmark-client-gc_%p.log"
-
-exec java -server -cp $CLASSPATH $JVM_MEM io.openmessaging.benchmark.worker.BenchmarkWorker $*
+# Required by Netty for optimized direct byte buffer access
+JVM_OPTS="$JVM_OPTS -Dio.netty.tryReflectionSetAccessible=true"
+JVM_OPTS="$JVM_OPTS --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED"
+# Set io.netty.tryReflectionSetAccessible in Pulsar's shaded client
+JVM_OPTS="$JVM_OPTS -Dorg.apache.pulsar.shade.io.netty.tryReflectionSetAccessible=true"
+# Required by Pulsar client optimized checksum calculation on other than Linux x86_64 platforms
+# reflection access to java.util.zip.CRC32C
+JVM_OPTS="$JVM_OPTS --add-opens java.base/java.util.zip=ALL-UNNAMED"
+exec java -server -cp $CLASSPATH $JVM_MEM $JVM_OPTS io.openmessaging.benchmark.worker.BenchmarkWorker "$@"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,12 +12,20 @@
 # limitations under the License.
 #
 
-FROM openjdk:8-jdk
+FROM eclipse-temurin:17
 
 ARG BENCHMARK_TARBALL
 
+# Using ADD instead of COPY because ${BENCHMARK_TARBALL} is an archive that needs to be extracted
 ADD ${BENCHMARK_TARBALL} /
 
 RUN mv openmessaging-benchmark-* /benchmark
 
 WORKDIR /benchmark
+
+# Install vim
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y vim tzdata && rm -rf /var/lib/apt/lists/*
+
+# Start a shell by default
+CMD ["/bin/bash"]

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -13,14 +13,21 @@
 #
 
 # Build the Project
-FROM maven:latest as build
+FROM maven:3.9.9-eclipse-temurin-17 as build
 COPY . /benchmark
 WORKDIR /benchmark
 RUN mvn install
 
 # Create the benchmark image
-FROM openjdk:8-jdk
+FROM eclipse-temurin:17
 COPY --from=build /benchmark/package/target/openmessaging-benchmark-*-SNAPSHOT-bin.tar.gz /
 RUN mkdir /benchmark && tar -xzf openmessaging-benchmark-*-SNAPSHOT-bin.tar.gz -C /benchmark --strip=1
 RUN rm /openmessaging-benchmark-*-SNAPSHOT-bin.tar.gz
 WORKDIR /benchmark
+
+# Install vim
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y vim tzdata && rm -rf /var/lib/apt/lists/*
+
+# Start a shell by default
+CMD ["/bin/bash"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,24 +1,31 @@
 # OpenMessaging Benchmark Framework Docker
 
+## Precondition
+
+You need to install [Eclipse Temurin 17](https://adoptium.net/)
+and set the JAVA_HOME environment variable to its installation directory.
+
+## Building the image
+
 You can use either of the Dockerfiles - `./docker/Dockerfile` or `./docker/Dockerfile.build` based on your needs.
 
 ### `Dockerfile`
 
-Uses `openjdk-8` and takes `BENCHMARK_TARBALL` as an argument.  
+Uses `eclipse-temurin:17` and takes `BENCHMARK_TARBALL` as an argument.
 While using this Dockerfile, you will need to build the project locally **first**.
 
 ```
 #> mvn build
 #> export BENCHMARK_TARBALL=package/target/openmessaging-benchmark-<VERSION>-SNAPSHOT-bin.tar.gz
-#> docker build --build-arg BENCHMARK_TARBALL . -f docker/Dockerfile
+#> docker build -t openmessaging-benchmark:latest --build-arg BENCHMARK_TARBALL . -f docker/Dockerfile
 ```
 
 ### `Dockerfile.build`
 
-Uses the latest version of `maven` in order to build the project, and then use `openjdk-8` as runtime.  
-This Dockerfile has no dependency (you do not need Mavent to be installed locally).
+Uses the latest version of `maven` in order to build the project, and then uses `eclipse-temurin:17` as runtime.
+This Dockerfile has no dependency (you do not need Maven to be installed locally).
 
 ```
-#> docker build . -f docker/Dockerfile.build
+#> docker build -t openmessaging-benchmark:latest . -f docker/Dockerfile.build
 ```
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,30 +2,47 @@
 
 ## Precondition
 
-You need to install [Eclipse Temurin 17](https://adoptium.net/)
+You need to install [Eclipse Temurin 17](https://adoptium.net/) (or 21)
 and set the JAVA_HOME environment variable to its installation directory.
 
 ## Building the image
 
-You can use either of the Dockerfiles - `./docker/Dockerfile` or `./docker/Dockerfile.build` based on your needs.
+You can use one of the Dockerfiles based on your needs:
+
+- `Dockerfile` - requires local build first
+- `Dockerfile.build` - builds inside Docker (JDK 17 only)
+- `Dockerfile.builder` - **recommended** - multi-JDK support (17 and 21)
+
+### `Dockerfile.builder` (Recommended)
+
+Supports both JDK 17 and JDK 21. Skips formatting checks that can have
+JDK version incompatibilities in container environments.
+
+```bash
+# Build with JDK 17 (default)
+docker build -t omb-benchmark:jdk17 -f docker/Dockerfile.builder .
+
+# Build with JDK 21
+docker build -t omb-benchmark:jdk21 --build-arg JDK_VERSION=21 -f docker/Dockerfile.builder .
+```
 
 ### `Dockerfile`
 
 Uses `eclipse-temurin:17` and takes `BENCHMARK_TARBALL` as an argument.
 While using this Dockerfile, you will need to build the project locally **first**.
 
-```
-#> mvn build
-#> export BENCHMARK_TARBALL=package/target/openmessaging-benchmark-<VERSION>-SNAPSHOT-bin.tar.gz
-#> docker build -t openmessaging-benchmark:latest --build-arg BENCHMARK_TARBALL . -f docker/Dockerfile
+```bash
+mvn install -DskipTests
+export BENCHMARK_TARBALL=package/target/openmessaging-benchmark-<VERSION>-SNAPSHOT-bin.tar.gz
+docker build -t openmessaging-benchmark:latest --build-arg BENCHMARK_TARBALL . -f docker/Dockerfile
 ```
 
 ### `Dockerfile.build`
 
-Uses the latest version of `maven` in order to build the project, and then uses `eclipse-temurin:17` as runtime.
-This Dockerfile has no dependency (you do not need Maven to be installed locally).
+Uses Maven to build the project inside Docker, then uses `eclipse-temurin:17` as runtime.
+This Dockerfile has no local dependency (you do not need Maven installed locally).
 
-```
-#> docker build -t openmessaging-benchmark:latest . -f docker/Dockerfile.build
+```bash
+docker build -t openmessaging-benchmark:latest . -f docker/Dockerfile.build
 ```
 

--- a/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/KafkaBenchmarkDriver.java
+++ b/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/KafkaBenchmarkDriver.java
@@ -45,6 +45,9 @@ import org.apache.kafka.common.serialization.StringSerializer;
 
 public class KafkaBenchmarkDriver implements BenchmarkDriver {
 
+    private static final String ZONE_ID_CONFIG = "zone.id";
+    private static final String ZONE_ID_TEMPLATE = "{zone.id}";
+    private static final String KAFKA_CLIENT_ID = "client.id";
     private Config config;
 
     private List<BenchmarkProducer> producers = Collections.synchronizedList(new ArrayList<>());
@@ -62,6 +65,13 @@ public class KafkaBenchmarkDriver implements BenchmarkDriver {
 
         Properties commonProperties = new Properties();
         commonProperties.load(new StringReader(config.commonConfig));
+
+        if (commonProperties.containsKey(KAFKA_CLIENT_ID)) {
+            commonProperties.put(
+                    KAFKA_CLIENT_ID,
+                    applyZoneId(
+                            commonProperties.getProperty(KAFKA_CLIENT_ID), System.getProperty(ZONE_ID_CONFIG)));
+        }
 
         producerProperties = new Properties();
         commonProperties.forEach((key, value) -> producerProperties.put(key, value));
@@ -149,6 +159,10 @@ public class KafkaBenchmarkDriver implements BenchmarkDriver {
             consumer.close();
         }
         admin.close();
+    }
+
+    private static String applyZoneId(String clientId, String zoneId) {
+        return clientId.replace(ZONE_ID_TEMPLATE, zoneId);
     }
 
     private static final ObjectMapper mapper =

--- a/driver-mqtt5/mqtt5.yaml
+++ b/driver-mqtt5/mqtt5.yaml
@@ -1,0 +1,27 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: MQTT
+driverClass: io.openmessaging.benchmark.driver.mqtt5.MqttBenchmarkDriver
+
+client:
+  serverUri: tcp://localhost:1883
+  username:
+  password:
+  topicPrefix: benchmark
+
+consumer:
+  cleanSession: true
+  sessionExpiryIntervalSeconds: 259200
+  receiveMaximum: 256

--- a/driver-mqtt5/pom.xml
+++ b/driver-mqtt5/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.openmessaging.benchmark</groupId>
+        <artifactId>messaging-benchmark</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>driver-mqtt5</artifactId>
+
+    <properties>
+        <hive.mqtt.client.verson>1.3.8</hive.mqtt.client.verson>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>driver-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.hivemq</groupId>
+            <artifactId>hivemq-mqtt-client</artifactId>
+            <version>${hive.mqtt.client.verson}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/driver-mqtt5/src/main/java/io/openmessaging/benchmark/driver/mqtt5/MqttBenchmarkConsumer.java
+++ b/driver-mqtt5/src/main/java/io/openmessaging/benchmark/driver/mqtt5/MqttBenchmarkConsumer.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openmessaging.benchmark.driver.mqtt5;
+
+
+import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient;
+import io.openmessaging.benchmark.driver.BenchmarkConsumer;
+
+public class MqttBenchmarkConsumer implements BenchmarkConsumer {
+    private Mqtt5AsyncClient client;
+    private volatile boolean closed = false;
+
+    public MqttBenchmarkConsumer() {}
+
+    @Override
+    public void close() throws Exception {
+        MqttBenchmarkDriver.closeClient(client);
+        closed = true;
+    }
+
+    public void setClient(Mqtt5AsyncClient client) {
+        this.client = client;
+    }
+
+    public boolean isClosed() {
+        return closed;
+    }
+}

--- a/driver-mqtt5/src/main/java/io/openmessaging/benchmark/driver/mqtt5/MqttBenchmarkDriver.java
+++ b/driver-mqtt5/src/main/java/io/openmessaging/benchmark/driver/mqtt5/MqttBenchmarkDriver.java
@@ -1,0 +1,388 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openmessaging.benchmark.driver.mqtt5;
+
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+import com.google.common.io.BaseEncoding;
+import com.google.common.net.HostAndPort;
+import com.hivemq.client.mqtt.MqttClientConfig;
+import com.hivemq.client.mqtt.MqttClientTransportConfig;
+import com.hivemq.client.mqtt.datatypes.MqttQos;
+import com.hivemq.client.mqtt.datatypes.MqttUtf8String;
+import com.hivemq.client.mqtt.lifecycle.MqttClientAutoReconnect;
+import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient;
+import com.hivemq.client.mqtt.mqtt5.Mqtt5Client;
+import com.hivemq.client.mqtt.mqtt5.Mqtt5ClientBuilder;
+import com.hivemq.client.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
+import com.hivemq.client.mqtt.mqtt5.datatypes.Mqtt5UserProperty;
+import com.hivemq.client.mqtt.mqtt5.message.connect.connack.Mqtt5ConnAck;
+import com.hivemq.client.mqtt.mqtt5.message.connect.connack.Mqtt5ConnAckReasonCode;
+import com.hivemq.client.mqtt.mqtt5.message.subscribe.Mqtt5Subscription;
+import com.hivemq.client.mqtt.mqtt5.message.subscribe.suback.Mqtt5SubAckReasonCode;
+import io.openmessaging.benchmark.driver.BenchmarkConsumer;
+import io.openmessaging.benchmark.driver.BenchmarkDriver;
+import io.openmessaging.benchmark.driver.BenchmarkProducer;
+import io.openmessaging.benchmark.driver.ConsumerCallback;
+import io.openmessaging.benchmark.driver.mqtt5.client.MqttConfig;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.bookkeeper.stats.StatsLogger;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MqttBenchmarkDriver implements BenchmarkDriver {
+
+    private static final Logger log = LoggerFactory.getLogger(MqttBenchmarkDriver.class);
+    private static final ObjectMapper mapper =
+            new ObjectMapper(new YAMLFactory())
+                    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    private static final ObjectWriter writer = new ObjectMapper().writerWithDefaultPrettyPrinter();
+    private static final Random random = new Random();
+    private static final Pattern server_uri_pattern =
+            Pattern.compile("(?:[^:]*://)?([^:]+)(?::(\\w+))?");
+    public static final MqttUtf8String USER_PROPERTY_KEY_PUBLISH_TIMESTAMP =
+            MqttUtf8String.of("benchmark-publish-timestamp");
+
+    private MqttConfig config;
+
+    @Override
+    public void initialize(File configurationFile, StatsLogger statsLogger)
+            throws IOException, InterruptedException {
+        this.config = readConfig(configurationFile);
+        log.info("MqttBenchmarkDriver configuration: {}", writer.writeValueAsString(config));
+    }
+
+    @Override
+    public String getTopicNamePrefix() {
+        return config.client.topicPrefix + "/test";
+    }
+
+    @Override
+    public CompletableFuture<Void> createTopic(String topic, int partitions) {
+        // MQTT topics are created on the fly when messages are published or subscribed to.
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<BenchmarkProducer> createProducer(String topic) {
+        CompletableFuture<BenchmarkProducer> future = new CompletableFuture<>();
+
+        MqttBenchmarkProducer producer = new MqttBenchmarkProducer(topic, config.client.qos);
+        Mqtt5ClientBuilder clientBuilder =
+                getClientBuilder(buildPublisherClientId(), producer::isClosed);
+        Mqtt5AsyncClient client = clientBuilder.buildAsync();
+        client
+                .connect()
+                .whenComplete(
+                        ((connAck, ex) -> {
+                            if (handleConnResult(client, connAck, ex, future)) {
+                                return;
+                            }
+                            producer.setClient(client);
+                            future.complete(producer);
+                        }));
+
+        return future;
+    }
+
+    @Override
+    public CompletableFuture<BenchmarkConsumer> createConsumer(
+            String topic, String subscriptionName, ConsumerCallback consumerCallback) {
+        CompletableFuture<BenchmarkConsumer> future = new CompletableFuture<>();
+
+        MqttQos qos = intToQoS(config.client.qos);
+        List<Mqtt5Subscription> subscriptions = new ArrayList<>();
+        Splitter.on(",")
+                .split(topic)
+                .forEach(
+                        topicFilter -> {
+                            topicFilter = topicFilter.trim();
+                            if (StringUtils.isNotEmpty(topicFilter)) {
+                                Mqtt5Subscription subscription =
+                                        Mqtt5Subscription.builder()
+                                                // Use subscriptionName as shared subscription group name
+                                                .topicFilter(toSharedSubscription(topicFilter, subscriptionName))
+                                                .qos(qos)
+                                                .build();
+                                subscriptions.add(subscription);
+                            }
+                        });
+
+        MqttBenchmarkConsumer consumer = new MqttBenchmarkConsumer();
+        Mqtt5ClientBuilder clientBuilder =
+                getClientBuilder(buildSubscriberClientId(), consumer::isClosed);
+        Mqtt5AsyncClient client = clientBuilder.buildAsync();
+        client
+                .subscribeWith()
+                .addSubscriptions(subscriptions)
+                .callback(
+                        message -> {
+                            long publishTime = extractPublishTimestamp(message.getUserProperties());
+                            consumerCallback.messageReceived(message.getPayloadAsBytes(), publishTime);
+                            message.acknowledge();
+                        })
+                .manualAcknowledgement(true)
+                .send()
+                .whenComplete(
+                        ((subAck, ex) -> {
+                            String clientId = extractClientId(client.getConfig());
+                            if (ex != null) {
+                                log.error(
+                                        "Client[{}] failed to subscribe, subscriptions={}",
+                                        clientId,
+                                        subscriptions,
+                                        ex);
+                            } else if (subAck == null || subAck.getReasonCodes().size() != subscriptions.size()) {
+                                log.error(
+                                        "Client[{}] received invalid subAck={}, subscriptions={}",
+                                        clientId,
+                                        subAck,
+                                        subscriptions);
+                            } else {
+                                int size = subAck.getReasonCodes().size();
+                                for (int i = 0; i < size; i++) {
+                                    Mqtt5SubAckReasonCode reasonCode = subAck.getReasonCodes().get(i);
+                                    Mqtt5Subscription subscription = subscriptions.get(i);
+                                    if (reasonCode == Mqtt5SubAckReasonCode.GRANTED_QOS_0
+                                            || reasonCode == Mqtt5SubAckReasonCode.GRANTED_QOS_1
+                                            || reasonCode == Mqtt5SubAckReasonCode.GRANTED_QOS_2) {
+                                        log.info(
+                                                "Client[{}] subscribed topic-filters={}, qos={}, granted-qos={}",
+                                                clientId,
+                                                subscription.getTopicFilter(),
+                                                subscription.getQos().getCode(),
+                                                reasonCode.getCode());
+                                    } else {
+                                        log.warn(
+                                                "Client[{}] failed to subscribe topic-filters={}, qos={}, "
+                                                        + "reason-code={}",
+                                                clientId,
+                                                subscription.getTopicFilter(),
+                                                subscription.getQos().getCode(),
+                                                reasonCode.name());
+                                    }
+                                }
+                            }
+                        }));
+
+        client
+                .connectWith()
+                .cleanStart(config.consumer.cleanSession)
+                .sessionExpiryInterval(
+                        config.consumer.cleanSession ? 0 : config.consumer.sessionExpiryInterval)
+                .restrictions()
+                .receiveMaximum(config.consumer.receiveMaximum)
+                .applyRestrictions()
+                .send()
+                .whenComplete(
+                        ((connAck, ex) -> {
+                            if (handleConnResult(client, connAck, ex, future)) {
+                                return;
+                            }
+                            consumer.setClient(client);
+                            future.complete(consumer);
+                        }));
+
+        return future;
+    }
+
+    private boolean handleConnResult(
+            Mqtt5AsyncClient client, Mqtt5ConnAck connAck, Throwable ex, CompletableFuture<?> future) {
+        if (ex != null) {
+            future.completeExceptionally(ex);
+            log.error(
+                    "Client[{}] failed to connect to MQTT broker", extractClientId(client.getConfig()), ex);
+            return true;
+        }
+        if (connAck.getReasonCode() != Mqtt5ConnAckReasonCode.SUCCESS) {
+            future.completeExceptionally(
+                    new RuntimeException("ConnAck-ReasonCode: " + connAck.getReasonCode()));
+            log.warn(
+                    "Client[{}] was rejected by MQTT broker, ConnAck-ReasonCode={}",
+                    extractClientId(client.getConfig()),
+                    connAck.getReasonCode());
+            return true;
+        }
+        return false;
+    }
+
+    private Mqtt5ClientBuilder getClientBuilder(String clientId, Supplier<Boolean> closed) {
+        HostAndPort hostAndPort = parseServerUri(this.config.client.serverUri);
+        Mqtt5ClientBuilder clientBuilder =
+                Mqtt5Client.builder()
+                        .identifier(clientId)
+                        .transportConfig(
+                                MqttClientTransportConfig.builder()
+                                        .serverHost(hostAndPort.getHost())
+                                        .serverPort(hostAndPort.getPort())
+                                        .socketConnectTimeout(3, TimeUnit.SECONDS)
+                                        .mqttConnectTimeout(3, TimeUnit.SECONDS)
+                                        .build());
+
+        // Simple Auth with username and password
+        if (StringUtils.isNotEmpty(this.config.client.username)
+                && StringUtils.isNotEmpty(this.config.client.password)) {
+            clientBuilder =
+                    clientBuilder
+                            .simpleAuth()
+                            .username(this.config.client.username)
+                            .password(this.config.client.password.getBytes(StandardCharsets.UTF_8))
+                            .applySimpleAuth();
+        }
+
+        // Auto reconnect with initial delay 100 mills, max delay 10 seconds
+        clientBuilder =
+                clientBuilder.automaticReconnect(
+                        MqttClientAutoReconnect.builder()
+                                .initialDelay(100, TimeUnit.MILLISECONDS)
+                                .maxDelay(10, TimeUnit.SECONDS)
+                                .build());
+
+        // Listen to connection events
+        clientBuilder =
+                clientBuilder
+                        .addConnectedListener(
+                                context ->
+                                        log.info(
+                                                "Client[{}] connected to MQTT broker {}",
+                                                extractClientId(context.getClientConfig()),
+                                                context.getClientConfig().getServerAddress()))
+                        .addDisconnectedListener(
+                                context -> {
+                                    String clientId1 = extractClientId(context.getClientConfig());
+                                    log.warn(
+                                            "Client[{}] lost connection to MQTT broker {}, by {}",
+                                            clientId1,
+                                            context.getClientConfig().getServerAddress(),
+                                            context.getSource().name(),
+                                            context.getCause());
+                                    if (closed.get()) {
+                                        log.warn(
+                                                "Client[{}] stops reconnecting to MQTT broker since the client"
+                                                        + " wasn't created successfully or has been stopped already",
+                                                clientId1);
+                                        context.getReconnector().reconnect(false);
+                                    }
+                                });
+
+        return clientBuilder;
+    }
+
+    @Override
+    public void close() throws Exception {
+        // Nothing to close
+    }
+
+    private static MqttConfig readConfig(File configurationFile) throws IOException {
+        return mapper.readValue(configurationFile, MqttConfig.class);
+    }
+
+    private static HostAndPort parseServerUri(String serverUri) {
+        Matcher matcher = server_uri_pattern.matcher(serverUri);
+        if (matcher.find()) {
+            String host = matcher.group(1);
+            String portStr = matcher.group(2);
+            int port = StringUtils.isNotEmpty(portStr) ? Integer.parseInt(portStr) : 80;
+            return HostAndPort.fromParts(host, port);
+        } else {
+            throw new IllegalArgumentException("Invalid serverUri: " + serverUri);
+        }
+    }
+
+    private static String getRandomString() {
+        byte[] buffer = new byte[5];
+        random.nextBytes(buffer);
+        return BaseEncoding.base64Url().omitPadding().encode(buffer);
+    }
+
+    private static String buildPublisherClientId() {
+        return Joiner.on("_").join("benchmark", "pub", getRandomString(), System.currentTimeMillis());
+    }
+
+    private static String buildSubscriberClientId() {
+        return Joiner.on("_").join("benchmark", "sub", getRandomString(), System.currentTimeMillis());
+    }
+
+    private static String extractClientId(MqttClientConfig clientConfig) {
+        if (clientConfig.getClientIdentifier().isPresent()) {
+            return clientConfig.getClientIdentifier().get().toString();
+        }
+        return "";
+    }
+
+    private static String toSharedSubscription(String topicFilter, String sharedGroup) {
+        if (StringUtils.isEmpty(topicFilter)) {
+            return topicFilter;
+        }
+
+        if (topicFilter.startsWith("$share")) {
+            return topicFilter;
+        }
+
+        return Joiner.on('/').join("$share", sharedGroup, topicFilter);
+    }
+
+    // Extract publishTimestamp from user properties, return System.currentTimeMillis() if not found
+    private static long extractPublishTimestamp(Mqtt5UserProperties userProperties) {
+        List<? extends Mqtt5UserProperty> propertyList = userProperties.asList();
+        for (Mqtt5UserProperty property : propertyList) {
+            if (USER_PROPERTY_KEY_PUBLISH_TIMESTAMP.equals(property.getName())) {
+                try {
+                    return Long.parseLong(property.getValue().toString());
+                } catch (NumberFormatException ignore) {
+                    return System.currentTimeMillis();
+                }
+            }
+        }
+        return System.currentTimeMillis();
+    }
+
+    public static MqttQos intToQoS(int val) {
+        MqttQos qos = MqttQos.fromCode(val);
+        if (qos == null) {
+            qos = MqttQos.AT_LEAST_ONCE;
+        }
+        return qos;
+    }
+
+    public static void closeClient(Mqtt5AsyncClient client) {
+        if (client != null) {
+            String clientId = String.valueOf(client.getConfig().getClientIdentifier());
+            log.info("Client[{}] disconnecting...", clientId);
+            client
+                    .disconnect()
+                    .exceptionally(
+                            ex -> {
+                                log.error("Client[{}] failed to disconnect", clientId, ex);
+                                return null;
+                            });
+        }
+    }
+}

--- a/driver-mqtt5/src/main/java/io/openmessaging/benchmark/driver/mqtt5/MqttBenchmarkProducer.java
+++ b/driver-mqtt5/src/main/java/io/openmessaging/benchmark/driver/mqtt5/MqttBenchmarkProducer.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openmessaging.benchmark.driver.mqtt5;
+
+
+import com.hivemq.client.mqtt.datatypes.MqttQos;
+import com.hivemq.client.mqtt.datatypes.MqttUtf8String;
+import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient;
+import com.hivemq.client.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
+import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5Publish;
+import io.openmessaging.benchmark.driver.BenchmarkProducer;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MqttBenchmarkProducer implements BenchmarkProducer {
+
+    private static final Logger log = LoggerFactory.getLogger(MqttBenchmarkProducer.class);
+
+    private final String topic;
+    private final MqttQos qos;
+    private Mqtt5AsyncClient client;
+    private volatile boolean closed = false;
+
+    public MqttBenchmarkProducer(String topic, int qosCode) {
+        this.topic = topic;
+        this.qos = MqttBenchmarkDriver.intToQoS(qosCode);
+    }
+
+    @Override
+    public CompletableFuture<Void> sendAsync(Optional<String> key, byte[] payload) {
+
+        Mqtt5UserProperties properties =
+                Mqtt5UserProperties.builder()
+                        .add(
+                                MqttBenchmarkDriver.USER_PROPERTY_KEY_PUBLISH_TIMESTAMP,
+                                MqttUtf8String.of(String.valueOf(System.currentTimeMillis())))
+                        .build();
+        Mqtt5Publish message =
+                Mqtt5Publish.builder()
+                        .topic(topic)
+                        .payload(payload)
+                        .qos(qos)
+                        .userProperties(properties)
+                        .build();
+
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        this.client
+                .publish(message)
+                .whenComplete(
+                        ((result, ex) -> {
+                            if (ex != null || result.getError().isPresent()) {
+                                Throwable error = ex != null ? ex : result.getError().get();
+                                future.completeExceptionally(error);
+                                log.error("Client[{}] failed to publish MQTT message, topic={}", topic, error);
+                            } else {
+                                future.complete(null);
+                            }
+                        }));
+
+        return future;
+    }
+
+    @Override
+    public void close() throws Exception {
+        MqttBenchmarkDriver.closeClient(client);
+        closed = true;
+    }
+
+    public void setClient(Mqtt5AsyncClient client) {
+        this.client = client;
+    }
+
+    public boolean isClosed() {
+        return closed;
+    }
+}

--- a/driver-mqtt5/src/main/java/io/openmessaging/benchmark/driver/mqtt5/client/MqttClientConfig.java
+++ b/driver-mqtt5/src/main/java/io/openmessaging/benchmark/driver/mqtt5/client/MqttClientConfig.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openmessaging.benchmark.driver.mqtt5.client;
+
+public class MqttClientConfig {
+    /** The MQTT server URI. */
+    public String serverUri = "tcp://localhost:1883";
+
+    /** The username used for MQTT server-side authentication. */
+    public String username = "";
+
+    /** The password that matches the username. */
+    public String password = "";
+
+    /** The Quality of Service level for message delivery (0, 1, or 2). */
+    public int qos = 1;
+
+    /** The topic prefix for topics used in the benchmark. No need to add a trailing slash. */
+    public String topicPrefix = "benchmark";
+}

--- a/driver-mqtt5/src/main/java/io/openmessaging/benchmark/driver/mqtt5/client/MqttConfig.java
+++ b/driver-mqtt5/src/main/java/io/openmessaging/benchmark/driver/mqtt5/client/MqttConfig.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openmessaging.benchmark.driver.mqtt5.client;
+
+public class MqttConfig {
+    public MqttClientConfig client = new MqttClientConfig();
+    public MqttConsumerConfig consumer = new MqttConsumerConfig();
+}

--- a/driver-mqtt5/src/main/java/io/openmessaging/benchmark/driver/mqtt5/client/MqttConsumerConfig.java
+++ b/driver-mqtt5/src/main/java/io/openmessaging/benchmark/driver/mqtt5/client/MqttConsumerConfig.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openmessaging.benchmark.driver.mqtt5.client;
+
+public class MqttConsumerConfig {
+    /** Consume in clean session mode or not. */
+    public Boolean cleanSession = true;
+
+    /** The session expiry interval in seconds when cleanSession is false. */
+    public Integer sessionExpiryInterval = 3 * 24 * 60 * 60;
+
+    /** The maximum number of unacknowledged QoS 1 and 2 messages. */
+    public Integer receiveMaximum = 256;
+}

--- a/driver-rocketmq5/pom.xml
+++ b/driver-rocketmq5/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.openmessaging.benchmark</groupId>
+        <artifactId>messaging-benchmark</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>driver-rocketmq5</artifactId>
+
+    <properties>
+        <rocketmq-client-java-version>5.0.7</rocketmq-client-java-version>
+        <rocketmq.version>5.1.0</rocketmq.version>
+        <guava.version>29.0-jre</guava.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>driver-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.rocketmq</groupId>
+            <artifactId>rocketmq-client-java</artifactId>
+            <version>${rocketmq-client-java-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.rocketmq</groupId>
+            <artifactId>rocketmq-tools</artifactId>
+            <version>${rocketmq.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/driver-rocketmq5/rocketmq.yaml
+++ b/driver-rocketmq5/rocketmq.yaml
@@ -1,0 +1,32 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: RocketMQ5
+driverClass: io.openmessaging.benchmark.driver.rocketmq.RocketMQ5BenchmarkDriver
+
+# The RocketMQ nameserver address
+namesrvAddr: x.x.x.x:9876
+# The RocketMQ broker cluster name
+clusterName: rocketmq-broker-xxxx
+# The proxy address to connect for grpc client.
+grpcEndpoint: 127.0.0.1:8081
+# 是否生产定时消息，否：生产普通消息，是：生产定时/延时消息且通过delayTimeInSec设置延迟时间
+sendDelayMsg: false
+delayTimeInSec: 60
+# (Optional) The admin credential
+adminAccessKey: xxxx
+adminSecretKey: xxxx
+# (Optional) The credential that clients connect to proxy.
+accessKey: xxxxxx
+secretKey: xxxxx

--- a/driver-rocketmq5/src/main/java/io/openmessaging/benchmark/driver/rocketmq/RocketMQ5BenchmarkConsumer.java
+++ b/driver-rocketmq5/src/main/java/io/openmessaging/benchmark/driver/rocketmq/RocketMQ5BenchmarkConsumer.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openmessaging.benchmark.driver.rocketmq;
+
+
+import io.openmessaging.benchmark.driver.BenchmarkConsumer;
+import org.apache.rocketmq.client.apis.consumer.PushConsumer;
+
+public class RocketMQ5BenchmarkConsumer implements BenchmarkConsumer {
+    private final PushConsumer rmqConsumer;
+
+    public RocketMQ5BenchmarkConsumer(final PushConsumer rmqConsumer) {
+        this.rmqConsumer = rmqConsumer;
+    }
+
+    @Override
+    public void close() throws Exception {
+        this.rmqConsumer.close();
+    }
+}

--- a/driver-rocketmq5/src/main/java/io/openmessaging/benchmark/driver/rocketmq/RocketMQ5BenchmarkDriver.java
+++ b/driver-rocketmq5/src/main/java/io/openmessaging/benchmark/driver/rocketmq/RocketMQ5BenchmarkDriver.java
@@ -1,0 +1,294 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openmessaging.benchmark.driver.rocketmq;
+
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.google.common.io.BaseEncoding;
+import io.openmessaging.benchmark.driver.BenchmarkConsumer;
+import io.openmessaging.benchmark.driver.BenchmarkDriver;
+import io.openmessaging.benchmark.driver.BenchmarkProducer;
+import io.openmessaging.benchmark.driver.ConsumerCallback;
+import io.openmessaging.benchmark.driver.rocketmq.client.RocketMQClient5Config;
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.bookkeeper.stats.StatsLogger;
+import org.apache.rocketmq.acl.common.AclClientRPCHook;
+import org.apache.rocketmq.acl.common.SessionCredentials;
+import org.apache.rocketmq.client.apis.ClientConfiguration;
+import org.apache.rocketmq.client.apis.ClientConfigurationBuilder;
+import org.apache.rocketmq.client.apis.ClientException;
+import org.apache.rocketmq.client.apis.ClientServiceProvider;
+import org.apache.rocketmq.client.apis.SessionCredentialsProvider;
+import org.apache.rocketmq.client.apis.StaticSessionCredentialsProvider;
+import org.apache.rocketmq.client.apis.consumer.ConsumeResult;
+import org.apache.rocketmq.client.apis.consumer.FilterExpression;
+import org.apache.rocketmq.client.apis.consumer.FilterExpressionType;
+import org.apache.rocketmq.client.apis.consumer.PushConsumer;
+import org.apache.rocketmq.client.apis.producer.Producer;
+import org.apache.rocketmq.client.exception.MQBrokerException;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.common.TopicConfig;
+import org.apache.rocketmq.common.attribute.TopicMessageType;
+import org.apache.rocketmq.remoting.exception.RemotingConnectException;
+import org.apache.rocketmq.remoting.exception.RemotingSendRequestException;
+import org.apache.rocketmq.remoting.exception.RemotingTimeoutException;
+import org.apache.rocketmq.remoting.protocol.subscription.SubscriptionGroupConfig;
+import org.apache.rocketmq.shaded.commons.lang3.StringUtils;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
+import org.apache.rocketmq.tools.admin.MQAdminExt;
+import org.apache.rocketmq.tools.command.CommandUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RocketMQ5BenchmarkDriver implements BenchmarkDriver {
+    private RocketMQClient5Config rmqClientConfig;
+    private DefaultMQAdminExt rmqAdmin;
+
+    @Override
+    public void initialize(final File configurationFile, final StatsLogger statsLogger)
+            throws IOException {
+        this.rmqClientConfig = readConfig(configurationFile);
+        if (isAdminAclEnabled()) {
+            AclClientRPCHook rpcHook =
+                    new AclClientRPCHook(
+                            new SessionCredentials(
+                                    this.rmqClientConfig.adminAccessKey, this.rmqClientConfig.adminSecretKey));
+            this.rmqAdmin = new DefaultMQAdminExt(rpcHook);
+        } else {
+            this.rmqAdmin = new DefaultMQAdminExt();
+        }
+        this.rmqAdmin.setNamesrvAddr(this.rmqClientConfig.namesrvAddr);
+        this.rmqAdmin.setInstanceName("AdminInstance-" + getRandomString());
+        try {
+            this.rmqAdmin.start();
+        } catch (MQClientException e) {
+            log.error("Start the RocketMQ admin tool failed.");
+        }
+    }
+
+    Map<String, Set<String>> cachedBrokerAddr = new ConcurrentHashMap<>();
+
+    private synchronized Set<String> fetchMasterAndSlaveAddrByClusterName(
+            final MQAdminExt adminExt, final String clusterName)
+            throws RemotingConnectException, RemotingSendRequestException, RemotingTimeoutException,
+                    MQBrokerException, InterruptedException {
+        Set<String> brokerList = cachedBrokerAddr.get(clusterName);
+        if (brokerList == null) {
+            brokerList =
+                    CommandUtil.fetchMasterAndSlaveAddrByClusterName(
+                            adminExt, this.rmqClientConfig.clusterName);
+            cachedBrokerAddr.put(clusterName, brokerList);
+            if (brokerList.isEmpty()) {
+                throw new RuntimeException("get brokerAddr return null, clusterName: " + clusterName);
+            }
+        }
+        return brokerList;
+    }
+
+    @Override
+    public String getTopicNamePrefix() {
+        return "Benchmark";
+    }
+
+    @Override
+    public CompletableFuture<Void> createTopic(final String topic, final int partitions) {
+        return CompletableFuture.runAsync(
+                () -> {
+                    TopicConfig topicConfig = new TopicConfig();
+                    topicConfig.setOrder(false);
+                    topicConfig.setPerm(6);
+                    topicConfig.setReadQueueNums(partitions);
+                    topicConfig.setWriteQueueNums(partitions);
+                    topicConfig.setTopicName(topic);
+                    Map<String, String> properties = new HashMap<>();
+                    String topicType =
+                            rmqClientConfig.sendDelayMsg
+                                    ? TopicMessageType.DELAY.getValue()
+                                    : TopicMessageType.NORMAL.getValue();
+                    properties.put("+message.type", topicType);
+                    topicConfig.setAttributes(properties);
+
+                    try {
+                        Set<String> brokerList =
+                                fetchMasterAndSlaveAddrByClusterName(
+                                        this.rmqAdmin, this.rmqClientConfig.clusterName);
+                        topicConfig.setReadQueueNums(Math.max(1, partitions / brokerList.size()));
+                        topicConfig.setWriteQueueNums(Math.max(1, partitions / brokerList.size()));
+
+                        for (String brokerAddr : brokerList) {
+                            this.rmqAdmin.createAndUpdateTopicConfig(brokerAddr, topicConfig);
+                        }
+                    } catch (Exception e) {
+                        throw new RuntimeException(
+                                String.format(
+                                        "Failed to create topic [%s] to cluster [%s]",
+                                        topic, this.rmqClientConfig.clusterName),
+                                e);
+                    }
+                });
+    }
+
+    @Override
+    public CompletableFuture<BenchmarkProducer> createProducer(final String topic) {
+
+        ClientServiceProvider provider = ClientServiceProvider.loadService();
+        ClientConfigurationBuilder builder =
+                ClientConfiguration.newBuilder().setEndpoints(this.rmqClientConfig.grpcEndpoint);
+        SessionCredentialsProvider sessionCredentialsProvider =
+                new StaticSessionCredentialsProvider(
+                        this.rmqClientConfig.accessKey, this.rmqClientConfig.secretKey);
+        ClientConfiguration configuration;
+        if (isAclEnabled()) {
+            builder.setCredentialProvider(sessionCredentialsProvider);
+            configuration = builder.build();
+        } else {
+            configuration = builder.build();
+        }
+
+        Producer rmqProducer;
+        try {
+            rmqProducer =
+                    provider
+                            .newProducerBuilder()
+                            .setTopics(topic)
+                            .setClientConfiguration(configuration)
+                            .build();
+        } catch (ClientException e) {
+            throw new RuntimeException(e);
+        }
+        if (this.rmqClientConfig.sendDelayMsg) {
+            return CompletableFuture.completedFuture(
+                    new RocketMQ5BenchmarkProducer(
+                            rmqProducer, topic, true, this.rmqClientConfig.delayTimeInSec));
+        } else {
+            return CompletableFuture.completedFuture(new RocketMQ5BenchmarkProducer(rmqProducer, topic));
+        }
+    }
+
+    public void createSubscriptionGroup(String fullSubName) {
+        try {
+            Set<String> brokerList =
+                    fetchMasterAndSlaveAddrByClusterName(this.rmqAdmin, this.rmqClientConfig.clusterName);
+            SubscriptionGroupConfig subscriptionGroupConfig = new SubscriptionGroupConfig();
+            subscriptionGroupConfig.setGroupName(fullSubName);
+
+            for (String brokerAddr : brokerList) {
+                this.rmqAdmin.createAndUpdateSubscriptionGroupConfig(brokerAddr, subscriptionGroupConfig);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    String.format(
+                            "Failed to create subscription [%s] to cluster [%s]",
+                            fullSubName, this.rmqClientConfig.clusterName),
+                    e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<BenchmarkConsumer> createConsumer(
+            final String topic, final String subscriptionName, final ConsumerCallback consumerCallback) {
+        PushConsumer rmqConsumer;
+
+        // To avoid bench-tool encounter subscription relationship conflict when specifying multiple
+        // topics, let's add topic name as subscription name prefix.
+        String subPrefix;
+        if (topic.contains("%")) {
+            subPrefix = topic.split("%")[1];
+        } else {
+            subPrefix = topic;
+        }
+        String fullSubName = String.format("%s_%s", subPrefix, subscriptionName);
+        createSubscriptionGroup(fullSubName);
+
+        ClientServiceProvider provider = ClientServiceProvider.loadService();
+        ClientConfigurationBuilder builder =
+                ClientConfiguration.newBuilder().setEndpoints(this.rmqClientConfig.grpcEndpoint);
+        SessionCredentialsProvider sessionCredentialsProvider =
+                new StaticSessionCredentialsProvider(
+                        this.rmqClientConfig.accessKey, this.rmqClientConfig.secretKey);
+        ClientConfiguration configuration;
+        if (isAclEnabled()) {
+            builder.setCredentialProvider(sessionCredentialsProvider);
+            configuration = builder.build();
+        } else {
+            configuration = builder.build();
+        }
+        FilterExpression filterExpression = new FilterExpression("*", FilterExpressionType.TAG);
+
+        try {
+            rmqConsumer =
+                    provider
+                            .newPushConsumerBuilder()
+                            .setClientConfiguration(configuration)
+                            // Set the consumer group name.
+                            .setConsumerGroup(fullSubName)
+                            // Set the subscription for the consumer.
+                            .setSubscriptionExpressions(Collections.singletonMap(topic, filterExpression))
+                            .setMessageListener(
+                                    messageView -> {
+                                        // Handle the received message and return consume result.
+                                        consumerCallback.messageReceived(
+                                                messageView.getBody(), messageView.getBornTimestamp());
+                                        return ConsumeResult.SUCCESS;
+                                    })
+                            .build();
+        } catch (ClientException e) {
+            throw new RuntimeException(e);
+        }
+        return CompletableFuture.completedFuture(new RocketMQ5BenchmarkConsumer(rmqConsumer));
+    }
+
+    public boolean isAclEnabled() {
+        return !(StringUtils.isAnyBlank(this.rmqClientConfig.accessKey, this.rmqClientConfig.secretKey)
+                || StringUtils.isAnyEmpty(this.rmqClientConfig.accessKey, this.rmqClientConfig.secretKey));
+    }
+
+    public boolean isAdminAclEnabled() {
+        return !(StringUtils.isAnyBlank(
+                        this.rmqClientConfig.adminAccessKey, this.rmqClientConfig.adminSecretKey)
+                || StringUtils.isAnyEmpty(
+                        this.rmqClientConfig.adminAccessKey, this.rmqClientConfig.adminSecretKey));
+    }
+
+    @Override
+    public void close() throws Exception {}
+
+    private static final ObjectMapper mapper =
+            new ObjectMapper(new YAMLFactory())
+                    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    private static RocketMQClient5Config readConfig(File configurationFile) throws IOException {
+        return mapper.readValue(configurationFile, RocketMQClient5Config.class);
+    }
+
+    private static final Random random = new Random();
+
+    private static String getRandomString() {
+        byte[] buffer = new byte[5];
+        random.nextBytes(buffer);
+        return BaseEncoding.base64Url().omitPadding().encode(buffer);
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(RocketMQ5BenchmarkDriver.class);
+}

--- a/driver-rocketmq5/src/main/java/io/openmessaging/benchmark/driver/rocketmq/RocketMQ5BenchmarkProducer.java
+++ b/driver-rocketmq5/src/main/java/io/openmessaging/benchmark/driver/rocketmq/RocketMQ5BenchmarkProducer.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openmessaging.benchmark.driver.rocketmq;
+
+
+import io.openmessaging.benchmark.driver.BenchmarkProducer;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.apache.rocketmq.client.apis.message.MessageBuilder;
+import org.apache.rocketmq.client.apis.producer.Producer;
+import org.apache.rocketmq.client.java.message.MessageBuilderImpl;
+
+public class RocketMQ5BenchmarkProducer implements BenchmarkProducer {
+    private final Producer rmqProducer;
+    private final String rmqTopic;
+    private final Boolean sendDelayMsg;
+    private final Long delayTimeInSec;
+
+    public RocketMQ5BenchmarkProducer(final Producer rmqProducer, final String rmqTopic) {
+        this.rmqProducer = rmqProducer;
+        this.rmqTopic = rmqTopic;
+        this.sendDelayMsg = false;
+        this.delayTimeInSec = 0L;
+    }
+
+    public RocketMQ5BenchmarkProducer(
+            final Producer rmqProducer,
+            final String rmqTopic,
+            Boolean sendDelayMsg,
+            Long delayTimeInSec) {
+        this.rmqProducer = rmqProducer;
+        this.rmqTopic = rmqTopic;
+        this.sendDelayMsg = sendDelayMsg;
+        this.delayTimeInSec = delayTimeInSec;
+    }
+
+    @Override
+    public CompletableFuture<Void> sendAsync(final Optional<String> key, final byte[] payload) {
+        MessageBuilder messageBuilder = new MessageBuilderImpl();
+        messageBuilder.setBody(payload);
+        messageBuilder.setTopic(this.rmqTopic);
+
+        key.ifPresent(messageBuilder::setKeys);
+
+        if (this.sendDelayMsg) {
+            // 延时消息，单位秒（s），在指定延迟时间（当前时间之后）进行投递，例如消息在10秒后投递。
+            long delayTime = System.currentTimeMillis() + this.delayTimeInSec * 1000;
+            // 设置消息需要被投递的时间。
+            messageBuilder.setDeliveryTimestamp(delayTime);
+        }
+
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        this.rmqProducer
+                .sendAsync(messageBuilder.build())
+                .whenComplete(
+                        (sendReceipt, throwable) -> {
+                            if (sendReceipt != null) {
+                                future.complete(null);
+                            } else {
+                                future.completeExceptionally(throwable);
+                            }
+                        });
+        return future;
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (rmqProducer != null) {
+            rmqProducer.close();
+        }
+    }
+}

--- a/driver-rocketmq5/src/main/java/io/openmessaging/benchmark/driver/rocketmq/client/RocketMQClient5Config.java
+++ b/driver-rocketmq5/src/main/java/io/openmessaging/benchmark/driver/rocketmq/client/RocketMQClient5Config.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openmessaging.benchmark.driver.rocketmq.client;
+
+public class RocketMQClient5Config {
+    public String namesrvAddr;
+    public String grpcEndpoint;
+    public String clusterName;
+    public String adminAccessKey;
+    public String adminSecretKey;
+    public String accessKey;
+    public String secretKey;
+    public boolean sendDelayMsg;
+    public Long delayTimeInSec;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -352,7 +352,13 @@
                 <version>${maven.surefire.plugin.version}</version>
                 <configuration>
                     <!-- Required by system-lambda test dependency -->
-                    <argLine>--add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                    <!-- Required by Netty for optimized direct byte buffer access -->
+                    <!-- Required by Pulsar client for optimized direct byte buffer access and optimized checksum calculation -->
+                    <argLine>--add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED
+                        -Dio.netty.tryReflectionSetAccessible=true
+                        --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
+                        -Dorg.apache.pulsar.shade.io.netty.tryReflectionSetAccessible=true
+                        --add-opens java.base/java.util.zip=ALL-UNNAMED</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         <module>driver-artemis</module>
         <module>driver-bookkeeper</module>
         <module>driver-rocketmq</module>
+        <module>driver-rocketmq5</module>
         <module>driver-nats</module>
         <module>driver-nats-streaming</module>
         <module>driver-nsq</module>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <checkstyle.version>10.3.3</checkstyle.version>
         <commons.lang3.version>3.12.0</commons.lang3.version>
         <log4j.version>2.20.0</log4j.version>
-        <lombok.version>1.18.24</lombok.version>
+        <lombok.version>1.18.36</lombok.version>
         <jackson.version>2.13.2</jackson.version>
         <jcommander.version>1.48</jcommander.version>
         <junit.jupiter.version>5.9.0</junit.jupiter.version>
@@ -83,7 +83,7 @@
         <checkstyle.plugin.version>3.2.0</checkstyle.plugin.version>
         <jacoco.plugin.version>0.8.8</jacoco.plugin.version>
         <license.plugin.version>4.1</license.plugin.version>
-        <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
+        <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
         <maven.enforcer.plugin.version>3.1.0</maven.enforcer.plugin.version>
         <maven.surefire.plugin.version>3.0.0-M7</maven.surefire.plugin.version>
         <spotbugs.plugin.version>4.7.2.0</spotbugs.plugin.version>
@@ -434,15 +434,19 @@
                         <plugin>
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-compiler-plugin</artifactId>
-                            <version>3.8.1</version>
+                            <version>3.13.0</version>
                             <configuration>
-                                <source>8</source>
-                                <target>8</target>
-                                <release>8</release>
+                                <release>17</release>
                                 <encoding>${project.build.sourceEncoding}</encoding>
                                 <showDeprecation>true</showDeprecation>
                                 <showWarnings>true</showWarnings>
-                                <optimize>true</optimize>
+                                <annotationProcessorPaths>
+                                    <path>
+                                        <groupId>org.projectlombok</groupId>
+                                        <artifactId>lombok</artifactId>
+                                        <version>${lombok.version}</version>
+                                    </path>
+                                </annotationProcessorPaths>
                             </configuration>
                         </plugin>
                     </plugins>
@@ -468,6 +472,13 @@
                                 <showDeprecation>true</showDeprecation>
                                 <showWarnings>true</showWarnings>
                                 <optimize>true</optimize>
+                                <annotationProcessorPaths>
+                                    <path>
+                                        <groupId>org.projectlombok</groupId>
+                                        <artifactId>lombok</artifactId>
+                                        <version>${lombok.version}</version>
+                                    </path>
+                                </annotationProcessorPaths>
                             </configuration>
                         </plugin>
                     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
         <module>docker</module>
         <module>driver-kop</module>
         <module>tool</module>
+        <module>driver-mqtt5</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
Manual resolution of the conflict the new weekly `merge-into-conduktor-gateway` bot job correctly
refused to push through automatically. Pulls in 6 upstream commits: RocketMQ5 driver, MQTT5
driver, message-size-distribution support, a Netty optimization, and Docker build fixes.

## The conflict, resolved

`docker/Dockerfile` and `docker/Dockerfile.build` both changed the same line — the runtime
image's `FROM`:
- `conduktor-gateway` (`fd9aef4`, earlier this session): `eclipse-temurin:8-jdk` — a minimal fix
  for `openjdk:8-jdk` 404ing on Docker Hub.
- upstream (`60f6c5b`): `eclipse-temurin:17` — a full, deliberate JDK 8→17 migration.

Took upstream's side. **Verified, not just theorized:** I pulled and ran both images directly.
The *current* `ghcr.io/conduktor/openmessaging-benchmark:conduktor-gateway` is NOT broken today -
it runs Java 8 bytecode on a Java 8 runtime and works fine, because `conduktor-gateway`'s own
`pom.xml` currently overrides the `modern-java-compile` profile to force `release=8` regardless
of the JDK compiling it. The reason to take upstream's Dockerfile change here is that **this PR
also merges in upstream's own `pom.xml` change**, which bumps that same profile to `release=17`
(part of their real JDK 8→17 migration, matching their READMEs) - unconflicted, so it lands
automatically. Taking that pom.xml change *without* also taking the Dockerfile change would
create a real break (release-17 bytecode on a JDK 8 runtime); taking both together (this PR)
keeps it consistent. Confirmed post-fix: `docker run ... ghcr.io/conduktor/openmessaging-benchmark:pr-24 bin/benchmark --help` runs cleanly on JDK 17.

## Housekeeping

This is the same branch name (`chore/sync-upstream-into-conduktor-gateway`) the scheduled bot job
uses - merging this now means next Monday's run finds `conduktor-gateway` already contains
`master`'s tip and skips cleanly with nothing to do.