### PR TITLE
Engine image: JDK 21 runtime, /opt/benchmark layout, RateController warmup-guard fix

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/RateController.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/RateController.java
@@ -27,18 +27,24 @@ class RateController {
     private final long receiveBacklogLimit;
     private final double minRampingFactor;
     private final double maxRampingFactor;
+    private final double warmupRateFraction;
 
     @Getter(PACKAGE)
     private double rampingFactor;
 
     private long previousTotalPublished = 0;
     private long previousTotalReceived = 0;
+    private boolean warmedUp = false;
 
     RateController() {
         publishBacklogLimit = Env.getLong("PUBLISH_BACKLOG_LIMIT", 1_000);
         receiveBacklogLimit = Env.getLong("RECEIVE_BACKLOG_LIMIT", 1_000);
         minRampingFactor = Env.getDouble("MIN_RAMPING_FACTOR", 0.01);
         maxRampingFactor = Env.getDouble("MAX_RAMPING_FACTOR", 1);
+        // Fraction of the offered rate the producer must reach before the controller starts
+        // adjusting. Until then the rate is HELD (see nextRate) so a still-starting producer
+        // isn't mistaken for a saturated one. 0 disables the guard (legacy behaviour).
+        warmupRateFraction = Env.getDouble("WARMUP_RATE_FRACTION", 0.5);
         rampingFactor = maxRampingFactor;
     }
 
@@ -56,6 +62,19 @@ class RateController {
                     rate,
                     rate(published, periodNanos),
                     rate(received, periodNanos));
+        }
+
+        // Startup guard: hold the offered rate until the producer has proven it can sustain it at
+        // least once. A control window sampled while the producer is still starting sees
+        // published << expected; treating that as saturation would crater the rate toward 0, from
+        // which the multiplicative ramp (rate + rate*factor) cannot recover — the observed encrypt
+        // finder collapse to ~1 msg/s. Once warmed, backoffs settle at the real achieved rate.
+        if (!warmedUp) {
+            if (published >= (long) (expected * warmupRateFraction)) {
+                warmedUp = true;
+            } else {
+                return rate;
+            }
         }
 
         long receiveBacklog = totalPublished - totalReceived;

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/RateController.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/RateController.java
@@ -56,13 +56,14 @@ class RateController {
         previousTotalPublished = totalPublished;
         previousTotalReceived = totalReceived;
 
-        if (log.isDebugEnabled()) {
-            log.debug(
-                    "Current rate: {} -- Publish rate {} -- Receive Rate: {}",
-                    rate,
-                    rate(published, periodNanos),
-                    rate(received, periodNanos));
-        }
+        // DIAGNOSTIC: info (not debug) so the finder trajectory emits regardless of the active
+        // log4j2 config (the slf4j binding is log4j2; debug-level knobs didn't take). Only active
+        // during a producerRate:0 finder, so it's quiet for fixed-rate sweeps/repeats.
+        log.info(
+                "FINDER-TRACE Current rate: {} -- Publish rate {} -- Receive Rate: {}",
+                rate,
+                rate(published, periodNanos),
+                rate(received, periodNanos));
 
         // Startup guard: hold the offered rate until the producer has proven it can sustain it at
         // least once. A control window sampled while the producer is still starting sees
@@ -93,7 +94,7 @@ class RateController {
     }
 
     private double nextRate(long periodNanos, long actual, long expected, long backlog, String type) {
-        log.debug("{} backlog: {}", type, backlog);
+        log.info("FINDER-TRACE {} backlog: {} -> backing off", type, backlog);
         rampDown();
         long nextExpected = Math.max(0, expected - backlog);
         double nextExpectedRate = rate(nextExpected, periodNanos);

--- a/benchmark-framework/src/test/java/io/openmessaging/benchmark/RateControllerTest.java
+++ b/benchmark-framework/src/test/java/io/openmessaging/benchmark/RateControllerTest.java
@@ -54,6 +54,23 @@ class RateControllerTest {
     }
 
     @Test
+    void heldDuringProducerStartupThenRampsUp() {
+        // The finder starts at 10k msg/s, but the first control window(s) can be sampled while the
+        // producer is still starting up (published ~ 0) — pronounced with the encrypt interceptor.
+        // Treating that as saturation craters the rate to ~0, from which the multiplicative ramp
+        // cannot recover (the observed encrypt-finder collapse to ~1 msg/s despite ~70k capacity).
+        // The controller must HOLD the offered rate until the producer proves it can sustain it.
+        rate = rateController.nextRate(rate, periodNanos, 0, 0);
+        assertThat(rate).isEqualTo(10_000);
+        // still basically nothing published — keep holding, do not crater
+        rate = rateController.nextRate(rate, periodNanos, 100, 100);
+        assertThat(rate).isEqualTo(10_000);
+        // producer comes up and sustains the offered rate -> controller engages and ramps up
+        rate = rateController.nextRate(rate, periodNanos, 10_100, 10_100);
+        assertThat(rate).isEqualTo(20_000);
+    }
+
+    @Test
     void rampUp() {
         assertThat(rateController.getRampingFactor()).isEqualTo(1);
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,16 +12,16 @@
 # limitations under the License.
 #
 
-FROM eclipse-temurin:17
+FROM eclipse-temurin:21
 
 ARG BENCHMARK_TARBALL
 
 # Using ADD instead of COPY because ${BENCHMARK_TARBALL} is an archive that needs to be extracted
 ADD ${BENCHMARK_TARBALL} /
 
-RUN mv openmessaging-benchmark-* /benchmark
+RUN mv openmessaging-benchmark-* /opt/benchmark
 
-WORKDIR /benchmark
+WORKDIR /opt/benchmark
 
 # Install vim
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -13,17 +13,17 @@
 #
 
 # Build the Project
-FROM maven:3.9.9-eclipse-temurin-17 as build
+FROM maven:3.9.9-eclipse-temurin-21 as build
 COPY . /benchmark
 WORKDIR /benchmark
 RUN mvn install
 
 # Create the benchmark image
-FROM eclipse-temurin:17
+FROM eclipse-temurin:21
 COPY --from=build /benchmark/package/target/openmessaging-benchmark-*-SNAPSHOT-bin.tar.gz /
-RUN mkdir /benchmark && tar -xzf openmessaging-benchmark-*-SNAPSHOT-bin.tar.gz -C /benchmark --strip=1
+RUN mkdir /opt/benchmark && tar -xzf openmessaging-benchmark-*-SNAPSHOT-bin.tar.gz -C /opt/benchmark --strip=1
 RUN rm /openmessaging-benchmark-*-SNAPSHOT-bin.tar.gz
-WORKDIR /benchmark
+WORKDIR /opt/benchmark
 
 # Install vim
 ENV DEBIAN_FRONTEND=noninteractive

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
         <maven.enforcer.plugin.version>3.1.0</maven.enforcer.plugin.version>
         <maven.surefire.plugin.version>3.0.0-M7</maven.surefire.plugin.version>
-        <spotbugs.plugin.version>4.7.2.0</spotbugs.plugin.version>
+        <spotbugs.plugin.version>4.7.3.6</spotbugs.plugin.version>
         <spotless.plugin.version>2.25.0</spotless.plugin.version>
     </properties>
 


### PR DESCRIPTION
## Summary

Satisfies the engine-image contract needed by `conduktor/omb-payloads`'s `Containerfile.worker`, which builds `FROM ${ENGINE_IMAGE}` and layers on an interceptor jar compiled to Java 21 bytecode. Unblocks omb-payloads Tasks 6 (release), 7 (harness repoint), 8 (AKS validation).

- `docker/Dockerfile` / `docker/Dockerfile.build`: runtime base `eclipse-temurin:17` → `21`, dist layout `/benchmark` → `/opt/benchmark`. Build stage in `Dockerfile.build` also bumped to `maven:3.9.9-eclipse-temurin-21` for consistency.
- `pom.xml`: `spotbugs-maven-plugin` `4.7.2.0` → `4.7.3.6` — the old version can't parse JDK 21's own bootstrap classes (class file major version 65), so `mvn install` under a JDK 21 toolchain failed during the spotbugs analysis phase regardless of the project's `--release` target. Found while verifying the build on JDK 21 per this PR's own requirements.
- Ports the RateController warmup-guard fix (`WARMUP_RATE_FRACTION`, default 0.5) and its `FINDER-TRACE` INFO logging from `origin/conduktor` (commits `2908135`, `58ee3b9`), which previously only existed on that now-superseded branch. Fixes the `producerRate:0` finder collapsing to ~1 msg/s by holding the offered rate until the producer proves it can sustain it.

Multi-arch (`linux/amd64,linux/arm64`) publishing to `ghcr.io/conduktor/openmessaging-benchmark` via `release.yml` was already in place from PR #20 — no changes needed there.

## Test plan
- [x] `mvn -pl benchmark-framework test -Dtest=RateControllerTest` passes on JDK 21, including the new `heldDuringProducerStartupThenRampsUp` test
- [x] Full reactor `mvn install -DskipTests` succeeds on JDK 21 (produces `package/target/openmessaging-benchmark-*-bin.tar.gz`)
- [x] `docker build -f docker/Dockerfile` succeeds locally against the produced tarball
- [x] Acceptance checks against the local image:
  - `java -version` → 21
  - `/opt/benchmark/bin` contains `benchmark-worker`
  - `/opt/benchmark` contains `lib`, `payload`
  - `bin/benchmark-worker --help` runs cleanly (no `UnsupportedClassVersionError`)
- [ ] Multi-arch + registry verification happens via CI once a release tag is pushed (not locally reproducible without buildx cross-arch emulation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)